### PR TITLE
Update create-pr command to use Cursor Memories for username

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -33,10 +33,9 @@ Examples:
 
 ```
 Create branch using pattern: {username}/GH-{ISSUE_NUMBER}--short-description
-  - Get current GitHub username dynamically (don't assume it's always "paulo")
-    * If username is not already saved in memory, retrieve it and save it for future use
-    * This avoids needing to look it up every time when creating branch names
-  - Note: This is the developer's GitHub username (which may differ from the repository owner)
+  - Get GitHub username from Cursor Memories:
+    * If username is NOT saved in Cursor Memories: Ask the user ONCE for their name, then save it in Cursor Memories
+    * If username IS saved in Cursor Memories: Use the saved username (DO NOT ask again, DO NOT check via terminal)
   - Extract issue number from GitHub issue
   - Create descriptive short description from issue title
   - Push branch to remote repository
@@ -50,8 +49,9 @@ Example: paulo/GH-123--add-habit-creation
 
 ```
 Use mcp_github_create_pull_request to create PR:
-  - owner: Get current GitHub username/owner dynamically (don't assume it's always "CalixtoTheBugHunter")
-    * Use saved username from memory if available, otherwise retrieve and save it
+  - owner: Use GitHub username from Cursor Memories (same username used for branch naming)
+    * If not in memory: Ask user ONCE, save in Cursor Memories, then use it
+    * If in memory: Use saved value (DO NOT ask again, DO NOT check via terminal)
   - repo: habit-tracker
   - title: Clear, descriptive title referencing issue
   - head: Branch name created in previous step
@@ -74,8 +74,11 @@ Note: GitHub automatically links PRs when using "Fixes #123" or "Closes #123" in
 ## Notes
 
 - This workflow uses MCP GitHub operations instead of CLI commands
-- Branch naming pattern: {username}/GH-{ISSUE_NUMBER}--short-description (username retrieved dynamically)
-- **GitHub Username**: Save the GitHub username in memory when first retrieved to avoid repeated lookups for branch naming
+- Branch naming pattern: {username}/GH-{ISSUE_NUMBER}--short-description
+- **GitHub Username**: 
+  * Ask the user ONCE for their GitHub username
+  * Save it in Cursor Memories immediately
+  * Always use the saved username from Cursor Memories in future runs
+  * NEVER check username via terminal commands
 - PR descriptions focus on user-facing value, not technical details
-- **Owner/Repository**: Always retrieve the current GitHub username/owner dynamically. Do not hardcode "CalixtoTheBugHunter" or assume a specific owner. The repository is always "habit-tracker" but the owner should be determined at runtime.
 


### PR DESCRIPTION
## Description
- Updated create-pr workflow to ask user once for GitHub username and save it in Cursor Memories
- Removed instructions that caused manual terminal checks for username
- Simplified workflow to always use saved username from Cursor Memories