### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/CalixtoTheBugHunter/habit-tracker/security/code-scanning/2](https://github.com/CalixtoTheBugHunter/habit-tracker/security/code-scanning/2)

To fix this issue, an explicit `permissions` key should be added either to the root of the workflow (applies to all jobs), or to the specific job(s) involved. Since the workflow only contains a single job (`lint`), adding the `permissions` block at the job level provides clarity and aligns with the typical structure. The minimal permissions required for this job, based on the steps performed (checking out code, installing dependencies, linting/audit, TypeScript checks), is `contents: read`. No write permissions are obviously needed for this workflow. To implement the fix, insert a `permissions:` block under the `lint:` job, with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
