### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CalixtoTheBugHunter/habit-tracker/security/code-scanning/1](https://github.com/CalixtoTheBugHunter/habit-tracker/security/code-scanning/1)

To fix this problem, add a `permissions` block with restrictive read-only settings at the job level under `test:` (on line 11 or 12) or at the workflow root, above `jobs:`, to explicitly minimize the GITHUB_TOKEN's privileges as recommended. Since there is only one job (`test`), placing it at the job level is precise, but placing it at the workflow root applies the restriction to all jobs (which is future-proof if more jobs are added). For this single-job workflow, either is acceptable, but the top-level is preferred for scalability. The actual required permission in this case is `contents: read`—no steps require additional privileges. Edit `.github/workflows/test.yml` and add the following block:

```yaml
permissions:
  contents: read
```

Place it after the `name:` line at the top of the file (before `on:`). No additional imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
