### PR TITLE
Auto-complete main habit when all stacked habits are done

### DIFF
--- a/src/components/habit/HabitForm/HabitForm.tsx
+++ b/src/components/habit/HabitForm/HabitForm.tsx
@@ -103,6 +103,7 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
         stackingHabits: hasStacking ? stackingHabitIds : undefined,
         stackingCompletions: hasStacking && Object.keys(stackingCompletions ?? {}).length > 0 ? stackingCompletions : undefined,
         stackingStepLabels: labelsForStack && Object.keys(labelsForStack).length > 0 ? labelsForStack : undefined,
+        autoCompletedDates: hasStacking ? habit?.autoCompletedDates : undefined,
       }
 
       if (isEditMode) {

--- a/src/components/habit/HabitList/HabitList.test.tsx
+++ b/src/components/habit/HabitList/HabitList.test.tsx
@@ -677,6 +677,70 @@ describe('HabitList', () => {
         )
       })
     })
+
+    it('marks parent complete with autoCompletedDates when last stacked habit is checked', async () => {
+      const user = userEvent.setup()
+      const todayIso = createDateString(0)
+      let db: Habit[] = [
+        createMockHabit({ id: '1', name: 'Exercise', stackingHabits: ['2', '3'], completionDates: [] }),
+        createMockHabit({ id: '2', name: 'Read', completionDates: [] }),
+        createMockHabit({ id: '3', name: 'Meditate', completionDates: [] }),
+      ]
+      vi.mocked(getAllHabits).mockImplementation(() => Promise.resolve(db))
+      vi.mocked(updateHabit).mockImplementation(async (h: Habit) => {
+        db = db.map(x => (x.id === h.id ? h : x))
+        return h.id
+      })
+
+      renderWithProviders(<HabitList />)
+
+      await screen.findByText('Exercise')
+      await user.click(screen.getByRole('button', { name: /expand stacked habits for exercise/i }))
+      await user.click(screen.getByRole('checkbox', { name: /mark read as done for today/i }))
+      await user.click(screen.getByRole('checkbox', { name: /mark meditate as done for today/i }))
+
+      await waitFor(() => {
+        expect(updateHabit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: '1',
+            completionDates: expect.arrayContaining([todayIso]),
+            autoCompletedDates: expect.arrayContaining([todayIso]),
+          })
+        )
+      })
+    })
+
+    it('does not clear manually completed parent when unchecking a stacked habit', async () => {
+      const user = userEvent.setup()
+      const todayIso = createDateString(0)
+      const habits = [
+        createMockHabit({
+          id: '1',
+          name: 'Exercise',
+          stackingHabits: ['2', '3'],
+          completionDates: [todayIso],
+        }),
+        createMockHabit({ id: '2', name: 'Read', completionDates: [todayIso] }),
+        createMockHabit({ id: '3', name: 'Meditate', completionDates: [todayIso] }),
+      ]
+      vi.mocked(getAllHabits).mockResolvedValue(habits)
+      vi.mocked(updateHabit).mockResolvedValue('1')
+
+      renderWithProviders(<HabitList />)
+
+      await screen.findByText('Exercise')
+      await user.click(screen.getByRole('button', { name: /expand stacked habits for exercise/i }))
+      await user.click(screen.getByRole('checkbox', { name: /mark meditate as done for today/i }))
+
+      await waitFor(() => {
+        expect(updateHabit).toHaveBeenCalled()
+      })
+
+      const parentCalls = vi.mocked(updateHabit).mock.calls.filter(
+        (call: [Habit]) => call[0].id === '1'
+      )
+      expect(parentCalls).toHaveLength(0)
+    })
   })
 })
 

--- a/src/components/habit/HabitList/HabitList.tsx
+++ b/src/components/habit/HabitList/HabitList.tsx
@@ -3,7 +3,7 @@ import { useHabits } from '../../../contexts/HabitContext'
 import { messages, formatMessage } from '../../../locale'
 import { calculateStreak } from '../../../utils/habit/calculateStreak'
 import { isTodayCompleted } from '../../../utils/habit/isTodayCompleted'
-import { toggleStackingHabitCompletion } from '../../../utils/habit/toggleStackingHabitCompletion'
+import { getHabitsToPersistAfterStackingToggle } from '../../../utils/habit/stackingCompletionCoordinator'
 import { AnnualCalendar } from '../AnnualCalendar/AnnualCalendar'
 import { HabitStackingAccordion } from '../HabitStackingAccordion/HabitStackingAccordion'
 import { ConfirmationModal } from '../../modal/ConfirmationModal/ConfirmationModal'
@@ -63,15 +63,12 @@ export function HabitList({ onEdit }: HabitListProps) {
   }
 
   const handleToggleStackingHabit = async (parentHabitId: string, stackingHabitId: string) => {
-    const parentHabit = habits.find(h => h.id === parentHabitId)
-    const stackingHabit = habits.find(h => h.id === stackingHabitId)
-    if (!parentHabit) return
+    if (!habits.find(h => h.id === parentHabitId)) return
+    const toPersist = getHabitsToPersistAfterStackingToggle(habits, parentHabitId, stackingHabitId)
+    if (toPersist.length === 0) return
     try {
-      if (stackingHabit) {
-        await toggleHabitCompletion(stackingHabitId)
-      } else {
-        const updated = toggleStackingHabitCompletion(parentHabit, stackingHabitId)
-        await updateHabit(updated)
+      for (const h of toPersist) {
+        await updateHabit(h)
       }
     } catch {
       // Error is already handled in context, but we catch to prevent unhandled promise rejection

--- a/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.css
+++ b/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.css
@@ -61,22 +61,30 @@
 }
 
 .habit-stacking-accordion__remove {
-  margin-left: var(--spacing-sm);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
-  padding: var(--spacing-xs);
+  margin-left: var(--spacing-sm);
+  padding: 0 var(--spacing-xs);
+  line-height: 0;
+  color: var(--color-error);
   background: none;
   border: none;
-  color: var(--color-error);
   cursor: pointer;
   border-radius: var(--radius-sm);
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.habit-stacking-accordion__remove-icon {
+  flex-shrink: 0;
+  color: inherit;
+  stroke: currentColor;
+  fill: none;
 }
 
 .habit-stacking-accordion__remove:hover {
-  background: var(--color-error-bg, rgba(211, 47, 47, 0.08));
+  opacity: 0.85;
 }
 
 .habit-stacking-accordion__remove:focus-visible {

--- a/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.tsx
+++ b/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.tsx
@@ -122,7 +122,7 @@ export function HabitStackingAccordion({
                       aria-label={formatMessage(messages.habitList.stacking.removeButtonAria, { name: displayName })}
                       onClick={() => handleRemoveClick(stackingHabitId, displayName)}
                     >
-                      <Trash2 aria-hidden size={16} />
+                      <Trash2 aria-hidden size={16} className="habit-stacking-accordion__remove-icon" />
                     </button>
                   )}
                 </li>
@@ -148,7 +148,7 @@ export function HabitStackingAccordion({
                     aria-label={formatMessage(messages.habitList.stacking.removeButtonAria, { name: displayName })}
                     onClick={() => handleRemoveClick(habit.id, displayName)}
                   >
-                    <Trash2 aria-hidden size={16} />
+                    <Trash2 aria-hidden size={16} className="habit-stacking-accordion__remove-icon" />
                   </button>
                 )}
               </li>

--- a/src/contexts/HabitContext.test.tsx
+++ b/src/contexts/HabitContext.test.tsx
@@ -226,6 +226,50 @@ describe('HabitContext', () => {
     })
   })
 
+  it('strips today from autoCompletedDates when toggling main completion off', async () => {
+    const today = createDateString(0)
+    const habit = createMockHabit({
+      id: '1',
+      name: 'Exercise',
+      completionDates: [today],
+      autoCompletedDates: [today],
+    })
+    const afterToggle = createMockHabit({
+      id: '1',
+      name: 'Exercise',
+      completionDates: [],
+    })
+
+    vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+    vi.mocked(getAllHabits).mockResolvedValueOnce([habit]).mockResolvedValue([afterToggle])
+    vi.mocked(updateHabit).mockResolvedValue('1')
+
+    let toggleFn: ((id: string) => Promise<void>) | null = null
+    const onToggle = (fn: (id: string) => Promise<void>) => {
+      toggleFn = fn
+    }
+
+    renderWithProviders(<TestComponentWithToggle onToggle={onToggle} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/habits: 1/i)).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      await toggleFn!('1')
+    })
+
+    await waitFor(() => {
+      expect(updateHabit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: '1',
+          completionDates: [],
+          autoCompletedDates: undefined,
+        })
+      )
+    })
+  })
+
   it('handles errors when toggling completion for non-existent habit', async () => {
     vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
     const habits = [createMockHabit({ id: '1', name: 'Exercise' })]

--- a/src/contexts/HabitContext.tsx
+++ b/src/contexts/HabitContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, useMemo, R
 import { messages } from '../locale'
 import { openDB, getAllHabits, updateHabit as updateHabitInDB, deleteHabit as deleteHabitFromDB } from '../services/indexedDB'
 import { toggleCompletion } from '../utils/habit/toggleCompletion'
+import { stripTodayFromAutoCompletedDates } from '../utils/habit/checkAutoCompletion'
 import { createAppError } from '../utils/error/errorTypes'
 import { logError } from '../utils/error/errorLogger'
 import type { Habit } from '../types/habit'
@@ -77,7 +78,7 @@ export function HabitProvider({ children }: HabitProviderProps) {
         throw new Error(`Habit with id ${habitId} not found`)
       }
 
-      const updatedHabit = toggleCompletion(habit)
+      const updatedHabit = stripTodayFromAutoCompletedDates(toggleCompletion(habit))
       await updateHabit(updatedHabit)
       await refreshHabits()
     } catch (err) {

--- a/src/types/habit.ts
+++ b/src/types/habit.ts
@@ -9,6 +9,7 @@
  * @property stackingHabits - Optional array of habit IDs (references to other habits or stacking-step identifiers)
  * @property stackingCompletions - Optional map of stacking habit ID to array of ISO 8601 completion date strings; used for stacking-only steps not in the main habits list
  * @property stackingStepLabels - Optional map of stacking-step ID to display name; used when that ID is not in the main habits list (stacking-only steps)
+ * @property autoCompletedDates - Optional array of ISO 8601 date strings for days the main habit was marked complete only because all stacked steps were done that day (not manual main completion)
  *
  * Constraints:
  * - id must be a non-empty string
@@ -25,5 +26,6 @@ export interface Habit {
   stackingHabits?: string[]
   stackingCompletions?: Record<string, string[]>
   stackingStepLabels?: Record<string, string>
+  autoCompletedDates?: string[]
 }
 

--- a/src/utils/habit/checkAutoCompletion.test.ts
+++ b/src/utils/habit/checkAutoCompletion.test.ts
@@ -67,6 +67,13 @@ describe('checkAutoCompletion', () => {
       })
       expect(hasAutoCompletedForToday(habit)).toBe(true)
     })
+
+    it('throws when autoCompletedDates contains an invalid date string', () => {
+      const habit = createMockHabit({
+        autoCompletedDates: ['not-a-date'],
+      })
+      expect(() => hasAutoCompletedForToday(habit)).toThrow(/Invalid date string/)
+    })
   })
 
   describe('syncParentMainCompletionWithStackingState', () => {

--- a/src/utils/habit/checkAutoCompletion.test.ts
+++ b/src/utils/habit/checkAutoCompletion.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  areAllStackedHabitsCompletedForToday,
+  hasAutoCompletedForToday,
+  syncParentMainCompletionWithStackingState,
+  stripTodayFromAutoCompletedDates,
+} from './checkAutoCompletion'
+import { createMockHabit } from '../../test/fixtures/habits'
+import { createDateString } from '../../test/utils/date-helpers'
+
+describe('checkAutoCompletion', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('areAllStackedHabitsCompletedForToday', () => {
+    it('returns false when stacking list is missing', () => {
+      const parent = createMockHabit({ id: 'p' })
+      expect(areAllStackedHabitsCompletedForToday(parent, [])).toBe(false)
+    })
+
+    it('returns false when stacking list is empty', () => {
+      const parent = createMockHabit({ id: 'p', stackingHabits: [] })
+      expect(areAllStackedHabitsCompletedForToday(parent, [])).toBe(false)
+    })
+
+    it('returns false when one resolved child is not done today', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({ id: 'p', stackingHabits: ['a', 'b'] })
+      const a = createMockHabit({ id: 'a', completionDates: [today] })
+      const b = createMockHabit({ id: 'b', completionDates: [] })
+      expect(areAllStackedHabitsCompletedForToday(parent, [a, b])).toBe(false)
+    })
+
+    it('returns true when all resolved children are done today', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({ id: 'p', stackingHabits: ['a', 'b'] })
+      const a = createMockHabit({ id: 'a', completionDates: [today] })
+      const b = createMockHabit({ id: 'b', completionDates: [today] })
+      expect(areAllStackedHabitsCompletedForToday(parent, [a, b])).toBe(true)
+    })
+
+    it('uses stackingCompletions when resolved habit is undefined', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({
+        id: 'p',
+        stackingHabits: ['step-1'],
+        stackingCompletions: { 'step-1': [today] },
+      })
+      expect(areAllStackedHabitsCompletedForToday(parent, [undefined])).toBe(true)
+    })
+  })
+
+  describe('hasAutoCompletedForToday', () => {
+    it('returns false when autoCompletedDates is missing', () => {
+      expect(hasAutoCompletedForToday(createMockHabit({}))).toBe(false)
+    })
+
+    it('returns true when an entry matches today', () => {
+      const habit = createMockHabit({
+        autoCompletedDates: [createDateString(0)],
+      })
+      expect(hasAutoCompletedForToday(habit)).toBe(true)
+    })
+  })
+
+  describe('syncParentMainCompletionWithStackingState', () => {
+    it('returns same reference when no stacking list', () => {
+      const parent = createMockHabit({ id: 'p' })
+      expect(syncParentMainCompletionWithStackingState(parent, [])).toBe(parent)
+    })
+
+    it('adds completion and auto when all stacked done and parent not complete', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({
+        id: 'p',
+        stackingHabits: ['a'],
+        completionDates: [],
+      })
+      const a = createMockHabit({ id: 'a', completionDates: [today] })
+      const result = syncParentMainCompletionWithStackingState(parent, [a])
+      expect(result).not.toBe(parent)
+      expect(result.completionDates).toContain(today)
+      expect(result.autoCompletedDates).toContain(today)
+    })
+
+    it('returns unchanged when parent already complete today', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({
+        id: 'p',
+        stackingHabits: ['a'],
+        completionDates: [today],
+      })
+      const a = createMockHabit({ id: 'a', completionDates: [today] })
+      expect(syncParentMainCompletionWithStackingState(parent, [a])).toBe(parent)
+    })
+
+    it('removes today from completion and auto when not all done and was auto-completed', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({
+        id: 'p',
+        stackingHabits: ['a', 'b'],
+        completionDates: [today],
+        autoCompletedDates: [today],
+      })
+      const a = createMockHabit({ id: 'a', completionDates: [today] })
+      const b = createMockHabit({ id: 'b', completionDates: [] })
+      const result = syncParentMainCompletionWithStackingState(parent, [a, b])
+      expect(result.completionDates).toHaveLength(0)
+      expect(result.autoCompletedDates).toBeUndefined()
+    })
+
+    it('does not remove main completion when complete today but not auto', () => {
+      const today = createDateString(0)
+      const parent = createMockHabit({
+        id: 'p',
+        stackingHabits: ['a', 'b'],
+        completionDates: [today],
+      })
+      const a = createMockHabit({ id: 'a', completionDates: [today] })
+      const b = createMockHabit({ id: 'b', completionDates: [] })
+      expect(syncParentMainCompletionWithStackingState(parent, [a, b])).toBe(parent)
+    })
+  })
+
+  describe('stripTodayFromAutoCompletedDates', () => {
+    it('returns same reference when no auto dates', () => {
+      const h = createMockHabit({})
+      expect(stripTodayFromAutoCompletedDates(h)).toBe(h)
+    })
+
+    it('removes only today from autoCompletedDates', () => {
+      const today = createDateString(0)
+      const yesterday = createDateString(1)
+      const h = createMockHabit({
+        autoCompletedDates: [today, yesterday],
+      })
+      const result = stripTodayFromAutoCompletedDates(h)
+      expect(result.autoCompletedDates).toEqual([yesterday])
+    })
+
+    it('sets autoCompletedDates undefined when empty after strip', () => {
+      const today = createDateString(0)
+      const h = createMockHabit({ autoCompletedDates: [today] })
+      const result = stripTodayFromAutoCompletedDates(h)
+      expect(result.autoCompletedDates).toBeUndefined()
+    })
+  })
+})

--- a/src/utils/habit/checkAutoCompletion.ts
+++ b/src/utils/habit/checkAutoCompletion.ts
@@ -38,7 +38,7 @@ export function hasAutoCompletedForToday(habit: Habit): boolean {
     return false
   }
   const todayStr = getTodayLocalDateString()
-  return dates.some(d => d.split('T')[0] === todayStr)
+  return dates.some(d => getDateString(d) === todayStr)
 }
 
 /**

--- a/src/utils/habit/checkAutoCompletion.ts
+++ b/src/utils/habit/checkAutoCompletion.ts
@@ -1,0 +1,106 @@
+import { getTodayLocalDateString, getDateString } from '../date/dateHelpers'
+import { isTodayCompleted } from './isTodayCompleted'
+import { isStackingHabitCompletedToday } from './isStackingHabitCompletedToday'
+import type { Habit } from '../../types/habit'
+
+/**
+ * Returns true if every stacking step is completed for today, using the same
+ * rules as HabitStackingAccordion (resolved habit vs stacking-only on parent).
+ */
+export function areAllStackedHabitsCompletedForToday(
+  parentHabit: Habit,
+  stackingHabitsResolved: (Habit | undefined)[]
+): boolean {
+  const ids = parentHabit.stackingHabits
+  if (!ids?.length) {
+    return false
+  }
+
+  for (let i = 0; i < ids.length; i++) {
+    const stackingHabitId = ids[i]!
+    const resolved = stackingHabitsResolved[i]
+    const stepDone =
+      resolved === undefined
+        ? isStackingHabitCompletedToday(parentHabit.stackingCompletions, stackingHabitId)
+        : isTodayCompleted(resolved.completionDates)
+    if (!stepDone) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/** True if autoCompletedDates records today (calendar day, local). */
+export function hasAutoCompletedForToday(habit: Habit): boolean {
+  const dates = habit.autoCompletedDates
+  if (!dates?.length) {
+    return false
+  }
+  const todayStr = getTodayLocalDateString()
+  return dates.some(d => d.split('T')[0] === todayStr)
+}
+
+/**
+ * Adds or removes main habit completion for today based on whether all stacked
+ * steps are done. Returns the same parent reference when nothing changes.
+ */
+export function syncParentMainCompletionWithStackingState(
+  parentHabit: Habit,
+  stackingHabitsResolved: (Habit | undefined)[]
+): Habit {
+  if (!parentHabit.stackingHabits?.length) {
+    return parentHabit
+  }
+
+  const todayStr = getTodayLocalDateString()
+  const todayISO = `${todayStr}T00:00:00.000Z`
+  const allDone = areAllStackedHabitsCompletedForToday(parentHabit, stackingHabitsResolved)
+
+  if (allDone) {
+    if (isTodayCompleted(parentHabit.completionDates)) {
+      return parentHabit
+    }
+    const nextAuto = [...(parentHabit.autoCompletedDates ?? [])]
+    if (!nextAuto.some(d => getDateString(d) === todayStr)) {
+      nextAuto.push(todayISO)
+    }
+    return {
+      ...parentHabit,
+      completionDates: [...parentHabit.completionDates, todayISO],
+      autoCompletedDates: nextAuto.length > 0 ? nextAuto : undefined,
+    }
+  }
+
+  if (isTodayCompleted(parentHabit.completionDates) && hasAutoCompletedForToday(parentHabit)) {
+    const nextCompletionDates = parentHabit.completionDates.filter(
+      dateStr => getDateString(dateStr) !== todayStr
+    )
+    const nextAuto =
+      parentHabit.autoCompletedDates?.filter(dateStr => getDateString(dateStr) !== todayStr) ?? []
+    return {
+      ...parentHabit,
+      completionDates: nextCompletionDates,
+      autoCompletedDates: nextAuto.length > 0 ? nextAuto : undefined,
+    }
+  }
+
+  return parentHabit
+}
+
+/** Removes today's calendar entries from autoCompletedDates. */
+export function stripTodayFromAutoCompletedDates(habit: Habit): Habit {
+  const dates = habit.autoCompletedDates
+  if (!dates?.length) {
+    return habit
+  }
+  const todayStr = getTodayLocalDateString()
+  const next = dates.filter(d => getDateString(d) !== todayStr)
+  if (next.length === dates.length) {
+    return habit
+  }
+  return {
+    ...habit,
+    autoCompletedDates: next.length > 0 ? next : undefined,
+  }
+}

--- a/src/utils/habit/stackingCompletionCoordinator.test.ts
+++ b/src/utils/habit/stackingCompletionCoordinator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getHabitsToPersistAfterStackingToggle } from './stackingCompletionCoordinator'
+import { createMockHabit } from '../../test/fixtures/habits'
+import { createDateString } from '../../test/utils/date-helpers'
+
+describe('stackingCompletionCoordinator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns parent with auto completion when second resolved child is toggled on', () => {
+    const today = createDateString(0)
+    const parent = createMockHabit({
+      id: 'p',
+      stackingHabits: ['a', 'b'],
+      completionDates: [],
+    })
+    const a = createMockHabit({ id: 'a', completionDates: [today] })
+    const b = createMockHabit({ id: 'b', completionDates: [] })
+    const habits = [parent, a, b]
+
+    const out = getHabitsToPersistAfterStackingToggle(habits, 'p', 'b')
+
+    expect(out).toHaveLength(2)
+    const [child, parentHabit] = out
+    expect(child!.id).toBe('b')
+    expect(child!.completionDates).toContain(today)
+    expect(parentHabit!.id).toBe('p')
+    expect(parentHabit!.completionDates).toContain(today)
+    expect(parentHabit!.autoCompletedDates).toContain(today)
+  })
+
+  it('returns child and parent clearing auto when unchecking after auto-complete', () => {
+    const today = createDateString(0)
+    const parent = createMockHabit({
+      id: 'p',
+      stackingHabits: ['a', 'b'],
+      completionDates: [today],
+      autoCompletedDates: [today],
+    })
+    const a = createMockHabit({ id: 'a', completionDates: [today] })
+    const b = createMockHabit({ id: 'b', completionDates: [today] })
+    const habits = [parent, a, b]
+
+    const out = getHabitsToPersistAfterStackingToggle(habits, 'p', 'b')
+
+    const [child, parentHabit] = out
+    expect(child!.id).toBe('b')
+    expect(child!.completionDates).toHaveLength(0)
+    expect(parentHabit!.id).toBe('p')
+    expect(parentHabit!.completionDates).toHaveLength(0)
+    expect(parentHabit!.autoCompletedDates).toBeUndefined()
+  })
+
+  it('handles stacking-only step on parent', () => {
+    const today = createDateString(0)
+    const parent = createMockHabit({
+      id: 'p',
+      stackingHabits: ['step-1'],
+      stackingCompletions: {},
+    })
+    const habits = [parent]
+
+    const out = getHabitsToPersistAfterStackingToggle(habits, 'p', 'step-1')
+
+    expect(out).toHaveLength(1)
+    const [only] = out
+    expect(only!.id).toBe('p')
+    expect(only!.stackingCompletions?.['step-1']).toContain(today)
+    expect(only!.completionDates).toContain(today)
+    expect(only!.autoCompletedDates).toContain(today)
+  })
+
+  it('returns empty array when parent is missing', () => {
+    expect(getHabitsToPersistAfterStackingToggle([], 'missing', 'x')).toEqual([])
+  })
+})

--- a/src/utils/habit/stackingCompletionCoordinator.ts
+++ b/src/utils/habit/stackingCompletionCoordinator.ts
@@ -1,0 +1,53 @@
+import type { Habit } from '../../types/habit'
+import { toggleCompletion } from './toggleCompletion'
+import { toggleStackingHabitCompletion } from './toggleStackingHabitCompletion'
+import { syncParentMainCompletionWithStackingState } from './checkAutoCompletion'
+
+function resolveStackingHabits(
+  parent: Habit,
+  habits: Habit[]
+): (Habit | undefined)[] {
+  const ids = parent.stackingHabits ?? []
+  return ids.map(id => habits.find(h => h.id === id))
+}
+
+/**
+ * Computes which habits must be persisted after toggling one stacked step.
+ * When both parent and child update, the child appears first in the array.
+ */
+export function getHabitsToPersistAfterStackingToggle(
+  habits: Habit[],
+  parentHabitId: string,
+  stackingHabitId: string
+): Habit[] {
+  const parentHabit = habits.find(h => h.id === parentHabitId)
+  if (!parentHabit) {
+    return []
+  }
+
+  const stackingHabit = habits.find(h => h.id === stackingHabitId)
+
+  if (stackingHabit) {
+    const toggledChild = toggleCompletion(stackingHabit)
+    const habitsNext = habits.map(h => (h.id === stackingHabitId ? toggledChild : h))
+    const parentAfter = habitsNext.find(h => h.id === parentHabitId)
+    if (!parentAfter?.stackingHabits?.length) {
+      return [toggledChild]
+    }
+    const resolved = resolveStackingHabits(parentAfter, habitsNext)
+    const parentFinal = syncParentMainCompletionWithStackingState(parentAfter, resolved)
+    if (parentFinal === parentAfter) {
+      return [toggledChild]
+    }
+    return [toggledChild, parentFinal]
+  }
+
+  const toggledParent = toggleStackingHabitCompletion(parentHabit, stackingHabitId)
+  const habitsNext = habits.map(h => (h.id === parentHabitId ? toggledParent : h))
+  if (!toggledParent.stackingHabits?.length) {
+    return [toggledParent]
+  }
+  const resolved = resolveStackingHabits(toggledParent, habitsNext)
+  const parentFinal = syncParentMainCompletionWithStackingState(toggledParent, resolved)
+  return [parentFinal]
+}

--- a/src/utils/validation/validateHabit.test.ts
+++ b/src/utils/validation/validateHabit.test.ts
@@ -70,6 +70,16 @@ describe('validateHabit', () => {
       }
       expect(() => validateHabit(habit)).not.toThrow()
     })
+
+    it('should validate habit with autoCompletedDates array', () => {
+      const habit: Habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        autoCompletedDates: ['2025-01-15T00:00:00.000Z'],
+      }
+      expect(() => validateHabit(habit)).not.toThrow()
+    })
   })
 
   describe('invalid habits', () => {
@@ -240,6 +250,26 @@ describe('validateHabit', () => {
         stackingStepLabels: { 'step-1': 123 },
       }
       expect(() => validateHabit(invalid)).toThrow('Habit stackingStepLabels values must be non-empty strings')
+    })
+
+    it('should reject habit with autoCompletedDates as non-array', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        autoCompletedDates: '2025-01-15T00:00:00.000Z',
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit autoCompletedDates must be an array if provided')
+    })
+
+    it('should reject habit with invalid ISO in autoCompletedDates', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        autoCompletedDates: ['not-a-date'],
+      }
+      expect(() => validateHabit(invalid)).toThrow('All autoCompletedDates must be valid ISO 8601 date strings')
     })
   })
 })

--- a/src/utils/validation/validateHabit.ts
+++ b/src/utils/validation/validateHabit.ts
@@ -83,6 +83,20 @@ export function validateHabit(habit: unknown): asserts habit is Habit {
     }
   }
 
+  if (habitObj.autoCompletedDates !== undefined) {
+    if (!Array.isArray(habitObj.autoCompletedDates)) {
+      throw new Error('Habit autoCompletedDates must be an array if provided')
+    }
+    for (const date of habitObj.autoCompletedDates) {
+      if (typeof date !== 'string') {
+        throw new Error('All autoCompletedDates must be strings')
+      }
+      if (!isValidISO8601(date)) {
+        throw new Error('All autoCompletedDates must be valid ISO 8601 date strings')
+      }
+    }
+  }
+
   if (habitObj.stackingStepLabels !== undefined) {
     if (typeof habitObj.stackingStepLabels !== 'object' || habitObj.stackingStepLabels === null || Array.isArray(habitObj.stackingStepLabels)) {
       throw new Error('Habit stackingStepLabels must be an object if provided')


### PR DESCRIPTION
Closes #88

## Description

- When every stacked habit is checked for today, the main habit is marked complete automatically—no extra tap.
- If you undo a stacked habit and the main habit was only completed by that flow, today’s completion is removed; manual completion stays intact.
- Clear feedback when the stack finishes (stacking UI reflects the main habit state right away).

GitHub issue: https://github.com/CalixtoTheBugHunter/habit-tracker/issues/88