### PR TITLE
feat(GH-67): add floating settings button in bottom-left corner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1027,9 +1027,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2475,9 +2475,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3327,9 +3327,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3381,9 +3381,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4811,9 +4811,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5163,9 +5163,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import { messages, formatMessage, getDefaultLocale } from './locale'
 import { HabitProvider, useHabits } from './contexts/HabitContext'
-import { HabitList, HabitForm, OfflineIndicator, InstallPrompt, ErrorBoundary } from './components'
+import { HabitList, HabitForm, OfflineIndicator, InstallPrompt, ErrorBoundary, SettingsButton } from './components'
 import type { Habit } from './types/habit'
 
 function AppContent() {
@@ -40,6 +40,7 @@ function AppContent() {
   return (
     <div className="app">
       <OfflineIndicator />
+      <SettingsButton onClick={() => {}} />
       <header className="app-header">
         <div className="app-header__content">
           <div>
@@ -49,7 +50,7 @@ function AppContent() {
         <InstallPrompt />
       </header>
       <main className="app-main">
-        <HabitForm 
+        <HabitForm
           habit={editingHabit}
           onSuccess={() => setEditingHabit(undefined)}
           onCancel={() => setEditingHabit(undefined)}

--- a/src/components/SettingsButton/SettingsButton.css
+++ b/src/components/SettingsButton/SettingsButton.css
@@ -30,6 +30,11 @@
   transform: scale(0.95);
 }
 
+.settings-button:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
 .settings-button__icon {
   color: var(--color-text-secondary);
 }

--- a/src/components/SettingsButton/SettingsButton.css
+++ b/src/components/SettingsButton/SettingsButton.css
@@ -1,0 +1,35 @@
+.settings-button {
+  position: fixed;
+  bottom: calc(1rem + env(safe-area-inset-bottom));
+  left: 1rem;
+  z-index: var(--z-index-indicator);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-base),
+    box-shadow var(--transition-base),
+    border-color var(--transition-base),
+    transform var(--transition-fast);
+}
+
+.settings-button:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.settings-button:active {
+  transform: scale(0.95);
+}
+
+.settings-button__icon {
+  color: var(--color-text-secondary);
+}

--- a/src/components/SettingsButton/SettingsButton.test.tsx
+++ b/src/components/SettingsButton/SettingsButton.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SettingsButton } from './SettingsButton'
-import { getButtonContrastRatio } from '../../test/utils/accessibility-helpers'
+import { verifyButtonContrast, mockComputedStyleForElement } from '../../test/utils/accessibility-helpers'
 
 describe('SettingsButton', () => {
   it('should render a button element', () => {
@@ -37,65 +37,27 @@ describe('SettingsButton', () => {
     expect(handleClick).toHaveBeenCalledTimes(1)
   })
 
-  it('should be keyboard accessible via Enter key', async () => {
-    const user = userEvent.setup()
-    const handleClick = vi.fn()
-
-    render(<SettingsButton onClick={handleClick} />)
-
-    const button = screen.getByRole('button')
-    button.focus()
-    await user.keyboard('{Enter}')
-
-    expect(handleClick).toHaveBeenCalledTimes(1)
-  })
-
-  it('should be keyboard accessible via Space key', async () => {
-    const user = userEvent.setup()
-    const handleClick = vi.fn()
-
-    render(<SettingsButton onClick={handleClick} />)
-
-    const button = screen.getByRole('button')
-    button.focus()
-    await user.keyboard(' ')
-
-    expect(handleClick).toHaveBeenCalledTimes(1)
-  })
-
-  it('should have settings-button class for styling', () => {
-    render(<SettingsButton onClick={() => {}} />)
-
-    expect(screen.getByRole('button')).toHaveClass('settings-button')
-  })
-
   describe('Accessibility - Contrast', () => {
+    let cleanup: (() => void) | undefined
+
+    afterEach(() => {
+      if (cleanup) {
+        cleanup()
+        cleanup = undefined
+      }
+    })
+
     it('should have sufficient contrast ratio', () => {
-      const originalGetComputedStyle = window.getComputedStyle
-      window.getComputedStyle = vi.fn((element: Element) => {
-        const style = originalGetComputedStyle(element)
-        if (element.classList.contains('settings-button')) {
-          return {
-            ...style,
-            color: 'rgb(102, 102, 102)',
-            backgroundColor: 'rgb(255, 255, 255)',
-            getPropertyValue: (prop: string) => {
-              if (prop === 'color') return 'rgb(102, 102, 102)'
-              if (prop === 'background-color') return 'rgb(255, 255, 255)'
-              return style.getPropertyValue(prop)
-            },
-          } as CSSStyleDeclaration
-        }
-        return style
-      }) as typeof window.getComputedStyle
+      cleanup = mockComputedStyleForElement(
+        'settings-button',
+        'rgb(102, 102, 102)',
+        'rgb(255, 255, 255)'
+      )
 
       render(<SettingsButton onClick={() => {}} />)
 
       const button = screen.getByRole('button') as HTMLElement
-      const contrastRatio = getButtonContrastRatio(button)
-      expect(contrastRatio).toBeGreaterThan(4.0)
-
-      window.getComputedStyle = originalGetComputedStyle
+      expect(verifyButtonContrast(button, 4.0)).toBe(true)
     })
   })
 })

--- a/src/components/SettingsButton/SettingsButton.test.tsx
+++ b/src/components/SettingsButton/SettingsButton.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SettingsButton } from './SettingsButton'
+import { getButtonContrastRatio } from '../../test/utils/accessibility-helpers'
+
+describe('SettingsButton', () => {
+  it('should render a button element', () => {
+    render(<SettingsButton onClick={() => {}} />)
+
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('should display a gear icon', () => {
+    render(<SettingsButton onClick={() => {}} />)
+
+    const button = screen.getByRole('button')
+    const icon = button.querySelector('svg')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('should have accessible aria-label', () => {
+    render(<SettingsButton onClick={() => {}} />)
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Open settings')
+  })
+
+  it('should call onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(<SettingsButton onClick={handleClick} />)
+
+    await user.click(screen.getByRole('button'))
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should be keyboard accessible via Enter key', async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(<SettingsButton onClick={handleClick} />)
+
+    const button = screen.getByRole('button')
+    button.focus()
+    await user.keyboard('{Enter}')
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should be keyboard accessible via Space key', async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(<SettingsButton onClick={handleClick} />)
+
+    const button = screen.getByRole('button')
+    button.focus()
+    await user.keyboard(' ')
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should have settings-button class for styling', () => {
+    render(<SettingsButton onClick={() => {}} />)
+
+    expect(screen.getByRole('button')).toHaveClass('settings-button')
+  })
+
+  describe('Accessibility - Contrast', () => {
+    it('should have sufficient contrast ratio', () => {
+      const originalGetComputedStyle = window.getComputedStyle
+      window.getComputedStyle = vi.fn((element: Element) => {
+        const style = originalGetComputedStyle(element)
+        if (element.classList.contains('settings-button')) {
+          return {
+            ...style,
+            color: 'rgb(102, 102, 102)',
+            backgroundColor: 'rgb(255, 255, 255)',
+            getPropertyValue: (prop: string) => {
+              if (prop === 'color') return 'rgb(102, 102, 102)'
+              if (prop === 'background-color') return 'rgb(255, 255, 255)'
+              return style.getPropertyValue(prop)
+            },
+          } as CSSStyleDeclaration
+        }
+        return style
+      }) as typeof window.getComputedStyle
+
+      render(<SettingsButton onClick={() => {}} />)
+
+      const button = screen.getByRole('button') as HTMLElement
+      const contrastRatio = getButtonContrastRatio(button)
+      expect(contrastRatio).toBeGreaterThan(4.0)
+
+      window.getComputedStyle = originalGetComputedStyle
+    })
+  })
+})

--- a/src/components/SettingsButton/SettingsButton.tsx
+++ b/src/components/SettingsButton/SettingsButton.tsx
@@ -1,0 +1,19 @@
+import { Settings } from 'lucide-react'
+import { messages } from '../../locale'
+import './SettingsButton.css'
+
+interface SettingsButtonProps {
+  onClick: () => void
+}
+
+export function SettingsButton({ onClick }: SettingsButtonProps) {
+  return (
+    <button
+      className="settings-button"
+      onClick={onClick}
+      aria-label={messages.settingsButton.ariaLabel}
+    >
+      <Settings className="settings-button__icon" size={24} aria-hidden="true" />
+    </button>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,3 +9,6 @@ export { OfflineIndicator, InstallPrompt } from './pwa'
 
 // Error components
 export { ErrorBoundary, ErrorFallback } from './error'
+
+// Settings components
+export { SettingsButton } from './SettingsButton/SettingsButton'

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -124,4 +124,7 @@ export const en = {
   errorBoundary: {
     reactRenderError: 'Something went wrong. Please refresh the page.',
   },
+  settingsButton: {
+    ariaLabel: 'Open settings',
+  },
 } as const

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -125,4 +125,7 @@ export const ptBR = {
   errorBoundary: {
     reactRenderError: 'Algo deu errado. Atualize a página.',
   },
+  settingsButton: {
+    ariaLabel: 'Abrir configurações',
+  },
 } as const


### PR DESCRIPTION
Closes #67

## Description
* Added a floating settings button (gear icon) fixed to the bottom-left corner of the screen
* Button is fully accessible with keyboard navigation, proper aria-label, and sufficient contrast ratio
* Supports safe-area insets for mobile devices and includes hover/active interaction states
* Localized aria-labels for both English and Portuguese (pt-BR)

## Screenshots