### PR TITLE
feat(GH-68): add Settings page with list of settings options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6229,9 +6229,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,13 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import { messages, formatMessage, getDefaultLocale } from './locale'
 import { HabitProvider, useHabits } from './contexts/HabitContext'
-import { HabitList, HabitForm, OfflineIndicator, InstallPrompt, ErrorBoundary, SettingsButton } from './components'
+import { HabitList, HabitForm, OfflineIndicator, InstallPrompt, ErrorBoundary, SettingsButton, Settings } from './components'
 import type { Habit } from './types/habit'
 
 function AppContent() {
   const { isLoading, error } = useHabits()
   const [editingHabit, setEditingHabit] = useState<Habit | undefined>(undefined)
+  const [showSettings, setShowSettings] = useState(false)
 
   if (isLoading) {
     return (
@@ -40,7 +41,8 @@ function AppContent() {
   return (
     <div className="app">
       <OfflineIndicator />
-      <SettingsButton onClick={() => {}} />
+      <SettingsButton onClick={() => setShowSettings(true)} />
+      {showSettings && <Settings onClose={() => setShowSettings(false)} />}
       <header className="app-header">
         <div className="app-header__content">
           <div>

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -1,0 +1,95 @@
+.settings {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--color-background);
+  z-index: var(--z-index-modal);
+  display: flex;
+  flex-direction: column;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.settings__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-xl) var(--spacing-2xl);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings__title {
+  font-size: var(--font-size-2xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.settings__close-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-md);
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.settings__close-button:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-surface-hover);
+}
+
+.settings__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-lg) 0;
+}
+
+.settings__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.settings__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--spacing-lg) var(--spacing-2xl);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+  text-align: left;
+  font-family: var(--font-family);
+}
+
+.settings__item:hover {
+  background-color: var(--color-surface-hover);
+}
+
+.settings__item-label {
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+}
+
+.settings__item-icon {
+  color: var(--color-text-tertiary);
+}
+
+@media (max-width: 600px) {
+  .settings__header {
+    padding: var(--spacing-lg);
+  }
+
+  .settings__item {
+    padding: var(--spacing-lg);
+  }
+}

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Settings } from './Settings'
+import { verifyButtonContrast, mockComputedStyleForElement } from '../../test/utils/accessibility-helpers'
+
+describe('Settings', () => {
+  it('should render the settings title', () => {
+    render(<Settings onClose={() => {}} />)
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
+  })
+
+  it('should render a close button with aria-label', () => {
+    render(<Settings onClose={() => {}} />)
+
+    const closeButton = screen.getByRole('button', { name: 'Close settings' })
+    expect(closeButton).toBeInTheDocument()
+  })
+
+  it('should render the Changelog item', () => {
+    render(<Settings onClose={() => {}} />)
+
+    expect(screen.getByRole('button', { name: /Changelog/ })).toBeInTheDocument()
+  })
+
+  it('should render a navigation list', () => {
+    render(<Settings onClose={() => {}} />)
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument()
+    expect(screen.getByRole('list')).toBeInTheDocument()
+  })
+
+  it('should call onClose when close button is clicked', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+
+    render(<Settings onClose={handleClose} />)
+
+    await user.click(screen.getByRole('button', { name: 'Close settings' }))
+
+    expect(handleClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onClose when Escape key is pressed', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+
+    render(<Settings onClose={handleClose} />)
+
+    await user.keyboard('{Escape}')
+
+    expect(handleClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onNavigateToChangelog when Changelog item is clicked', async () => {
+    const user = userEvent.setup()
+    const handleNavigate = vi.fn()
+
+    render(<Settings onClose={() => {}} onNavigateToChangelog={handleNavigate} />)
+
+    await user.click(screen.getByRole('button', { name: /Changelog/ }))
+
+    expect(handleNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not crash when Changelog is clicked without onNavigateToChangelog', async () => {
+    const user = userEvent.setup()
+
+    render(<Settings onClose={() => {}} />)
+
+    await user.click(screen.getByRole('button', { name: /Changelog/ }))
+  })
+
+  describe('Accessibility - Contrast', () => {
+    let cleanup: (() => void) | undefined
+
+    afterEach(() => {
+      if (cleanup) {
+        cleanup()
+        cleanup = undefined
+      }
+    })
+
+    it('should have sufficient contrast ratio on close button', () => {
+      cleanup = mockComputedStyleForElement(
+        'settings__close-button',
+        'rgb(102, 102, 102)',
+        'rgb(245, 245, 245)'
+      )
+
+      render(<Settings onClose={() => {}} />)
+
+      const closeButton = screen.getByRole('button', { name: 'Close settings' })
+      expect(verifyButtonContrast(closeButton, 4.0)).toBe(true)
+    })
+  })
+})

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import { X, ChevronRight } from 'lucide-react'
+import { messages } from '../../locale'
+import './Settings.css'
+
+interface SettingsProps {
+  onClose: () => void
+  onNavigateToChangelog?: () => void
+}
+
+export function Settings({ onClose, onNavigateToChangelog }: SettingsProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return (
+    <div className="settings">
+      <header className="settings__header">
+        <h1 className="settings__title">{messages.settings.title}</h1>
+        <button
+          className="settings__close-button"
+          onClick={onClose}
+          aria-label={messages.settings.close}
+        >
+          <X size={24} aria-hidden="true" />
+        </button>
+      </header>
+      <nav className="settings__nav">
+        <ul className="settings__list">
+          <li>
+            <button
+              className="settings__item"
+              onClick={() => onNavigateToChangelog?.()}
+            >
+              <span className="settings__item-label">
+                {messages.settings.items.changelog}
+              </span>
+              <ChevronRight
+                className="settings__item-icon"
+                size={20}
+                aria-hidden="true"
+              />
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,4 @@ export { ErrorBoundary, ErrorFallback } from './error'
 
 // Settings components
 export { SettingsButton } from './SettingsButton/SettingsButton'
+export { Settings } from './Settings/Settings'

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -127,4 +127,11 @@ export const en = {
   settingsButton: {
     ariaLabel: 'Open settings',
   },
+  settings: {
+    title: 'Settings',
+    close: 'Close settings',
+    items: {
+      changelog: 'Changelog',
+    },
+  },
 } as const

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -128,4 +128,11 @@ export const ptBR = {
   settingsButton: {
     ariaLabel: 'Abrir configurações',
   },
+  settings: {
+    title: 'Configurações',
+    close: 'Fechar configurações',
+    items: {
+      changelog: 'Registro de alterações',
+    },
+  },
 } as const


### PR DESCRIPTION
Closes #68

## Description
* Added full-page Settings overlay accessible via the floating settings button
* Settings page displays a navigable list of settings items, starting with Changelog
* Includes close button and Escape key support for easy dismissal
* Responsive design with dark mode support using existing CSS variables
* Full i18n support with English and Portuguese translations

## Screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)