### PR TITLE
feat(settings): language selection with device detection (#83)

### DIFF
--- a/.cursor/rules/github-cli-auth.mdc
+++ b/.cursor/rules/github-cli-auth.mdc
@@ -1,0 +1,14 @@
+---
+description: GitHub CLI must use CalixtoTheBugHunter for authenticated gh commands in this repo.
+alwaysApply: true
+---
+
+# GitHub CLI authentication (habit-tracker)
+
+Before running any **`gh`** command that talks to GitHub with the user’s credentials (for example `gh pr create`, `gh pr view`, `gh issue`, `gh api`, `gh repo`, `gh workflow`, `gh release`), run:
+
+```bash
+gh auth switch -u CalixtoTheBugHunter
+```
+
+Then run the intended `gh` command. This keeps the active account **CalixtoTheBugHunter** when multiple GitHub accounts are logged in on the machine.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import App from './App'
 import { openDB, getAllHabits } from './services/indexedDB'
 import { testUtils } from './services/indexedDB'
-import { renderWithProviders } from './test/utils/render-helpers'
 
 vi.mock('./services/indexedDB', () => ({
   openDB: vi.fn(),
@@ -31,7 +30,7 @@ describe('App', () => {
     vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
     vi.mocked(getAllHabits).mockResolvedValue([])
 
-    renderWithProviders(<App />)
+    render(<App />)
 
     await waitFor(() => {
       const element = screen.getByRole(role, { name: text })
@@ -43,7 +42,7 @@ describe('App', () => {
   it('handles errors and displays them in App UI', async () => {
     vi.mocked(openDB).mockRejectedValue(new Error('IndexedDB is not supported in this browser'))
 
-    renderWithProviders(<App />)
+    render(<App />)
 
     await waitFor(() => {
       expect(screen.getByText(/failed to initialize application/i)).toBeInTheDocument()
@@ -53,7 +52,7 @@ describe('App', () => {
   it('handles non-Error exceptions', async () => {
     vi.mocked(openDB).mockRejectedValue('String error')
 
-    renderWithProviders(<App />)
+    render(<App />)
 
     await waitFor(() => {
       expect(screen.getByText(/failed to initialize application/i)).toBeInTheDocument()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,21 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import './App.css'
-import { messages, formatMessage, getDefaultLocale } from './locale'
+import { formatMessage } from './locale'
+import { LanguageProvider, useLanguage } from './contexts/LanguageContext'
 import { HabitProvider, useHabits } from './contexts/HabitContext'
-import { HabitList, HabitForm, OfflineIndicator, InstallPrompt, ErrorBoundary, SettingsButton, Settings } from './components'
+import {
+  HabitList,
+  HabitForm,
+  OfflineIndicator,
+  InstallPrompt,
+  ErrorBoundary,
+  SettingsButton,
+  Settings,
+} from './components'
 import type { Habit } from './types/habit'
 
 function AppContent() {
+  const { messages } = useLanguage()
   const { isLoading, error } = useHabits()
   const [editingHabit, setEditingHabit] = useState<Habit | undefined>(undefined)
   const [showSettings, setShowSettings] = useState(false)
@@ -64,17 +74,15 @@ function AppContent() {
 }
 
 function App() {
-  useEffect(() => {
-    document.documentElement.lang = getDefaultLocale()
-  }, [])
   return (
-    <ErrorBoundary>
-      <HabitProvider>
-        <AppContent />
-      </HabitProvider>
-    </ErrorBoundary>
+    <LanguageProvider>
+      <ErrorBoundary>
+        <HabitProvider>
+          <AppContent />
+        </HabitProvider>
+      </ErrorBoundary>
+    </LanguageProvider>
   )
 }
 
 export default App
-

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -56,6 +56,31 @@
   margin: 0;
 }
 
+.settings__language-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg) var(--spacing-2xl);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings__language-label {
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.settings__language-select {
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+  max-width: 100%;
+}
+
 .settings__item {
   display: flex;
   align-items: center;
@@ -90,6 +115,10 @@
   }
 
   .settings__item {
+    padding: var(--spacing-lg);
+  }
+
+  .settings__language-row {
     padding: var(--spacing-lg);
   }
 }

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -1,31 +1,78 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Settings } from './Settings'
 import { verifyButtonContrast, mockComputedStyleForElement } from '../../test/utils/accessibility-helpers'
+import { renderWithProviders } from '../../test/utils/render-helpers'
+import * as languageStorage from '../../services/languageStorage'
+import { openDB, getAllHabits } from '../../services/indexedDB'
+
+vi.mock('../../services/indexedDB', () => ({
+  openDB: vi.fn(),
+  getAllHabits: vi.fn(),
+  addHabit: vi.fn(),
+  updateHabit: vi.fn(),
+  deleteHabit: vi.fn(),
+  testUtils: { resetDB: vi.fn() },
+}))
 
 describe('Settings', () => {
-  it('should render the settings title', () => {
-    render(<Settings onClose={() => {}} />)
+  beforeEach(() => {
+    vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+    vi.mocked(getAllHabits).mockResolvedValue([])
+    vi.mocked(languageStorage.getPreferredLanguage).mockResolvedValue('en')
+    vi.mocked(languageStorage.setPreferredLanguage).mockResolvedValue(undefined)
+  })
+
+  async function renderReady(ui: ReactElement) {
+    renderWithProviders(ui)
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
+    })
+  }
+
+  it('should render the settings title', async () => {
+    await renderReady(<Settings onClose={() => {}} />)
 
     expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument()
   })
 
-  it('should render a close button with aria-label', () => {
-    render(<Settings onClose={() => {}} />)
+  it('should render a close button with aria-label', async () => {
+    await renderReady(<Settings onClose={() => {}} />)
 
     const closeButton = screen.getByRole('button', { name: 'Close settings' })
     expect(closeButton).toBeInTheDocument()
   })
 
-  it('should render the Changelog item', () => {
-    render(<Settings onClose={() => {}} />)
+  it('should render the Changelog item', async () => {
+    await renderReady(<Settings onClose={() => {}} />)
 
     expect(screen.getByRole('button', { name: /Changelog/ })).toBeInTheDocument()
   })
 
-  it('should render a navigation list', () => {
-    render(<Settings onClose={() => {}} />)
+  it('should render preferred language select', async () => {
+    await renderReady(<Settings onClose={() => {}} />)
+
+    expect(screen.getByRole('combobox', { name: 'Preferred language' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Português' })).toBeInTheDocument()
+  })
+
+  it('should call setPreferredLanguage when language changes', async () => {
+    const user = userEvent.setup()
+    await renderReady(<Settings onClose={() => {}} />)
+
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'Preferred language' }),
+      'pt-BR'
+    )
+
+    expect(languageStorage.setPreferredLanguage).toHaveBeenCalledWith('pt-BR')
+  })
+
+  it('should render a navigation list', async () => {
+    await renderReady(<Settings onClose={() => {}} />)
 
     expect(screen.getByRole('navigation')).toBeInTheDocument()
     expect(screen.getByRole('list')).toBeInTheDocument()
@@ -35,7 +82,7 @@ describe('Settings', () => {
     const user = userEvent.setup()
     const handleClose = vi.fn()
 
-    render(<Settings onClose={handleClose} />)
+    await renderReady(<Settings onClose={handleClose} />)
 
     await user.click(screen.getByRole('button', { name: 'Close settings' }))
 
@@ -46,7 +93,7 @@ describe('Settings', () => {
     const user = userEvent.setup()
     const handleClose = vi.fn()
 
-    render(<Settings onClose={handleClose} />)
+    await renderReady(<Settings onClose={handleClose} />)
 
     await user.keyboard('{Escape}')
 
@@ -57,7 +104,9 @@ describe('Settings', () => {
     const user = userEvent.setup()
     const handleNavigate = vi.fn()
 
-    render(<Settings onClose={() => {}} onNavigateToChangelog={handleNavigate} />)
+    await renderReady(
+      <Settings onClose={() => {}} onNavigateToChangelog={handleNavigate} />
+    )
 
     await user.click(screen.getByRole('button', { name: /Changelog/ }))
 
@@ -67,7 +116,7 @@ describe('Settings', () => {
   it('should not crash when Changelog is clicked without onNavigateToChangelog', async () => {
     const user = userEvent.setup()
 
-    render(<Settings onClose={() => {}} />)
+    await renderReady(<Settings onClose={() => {}} />)
 
     await user.click(screen.getByRole('button', { name: /Changelog/ }))
   })
@@ -82,14 +131,14 @@ describe('Settings', () => {
       }
     })
 
-    it('should have sufficient contrast ratio on close button', () => {
+    it('should have sufficient contrast ratio on close button', async () => {
       cleanup = mockComputedStyleForElement(
         'settings__close-button',
         'rgb(102, 102, 102)',
         'rgb(245, 245, 245)'
       )
 
-      render(<Settings onClose={() => {}} />)
+      await renderReady(<Settings onClose={() => {}} />)
 
       const closeButton = screen.getByRole('button', { name: 'Close settings' })
       expect(verifyButtonContrast(closeButton, 4.0)).toBe(true)

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { X, ChevronRight } from 'lucide-react'
-import { messages } from '../../locale'
+import { useLanguage } from '../../contexts/LanguageContext'
+import type { LocaleCode } from '../../locale/types'
 import './Settings.css'
 
 interface SettingsProps {
@@ -9,6 +10,8 @@ interface SettingsProps {
 }
 
 export function Settings({ onClose, onNavigateToChangelog }: SettingsProps) {
+  const { messages, locale, setLanguage, supportedLanguages } = useLanguage()
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -34,6 +37,29 @@ export function Settings({ onClose, onNavigateToChangelog }: SettingsProps) {
       </header>
       <nav className="settings__nav">
         <ul className="settings__list">
+          <li className="settings__language-row">
+            <label
+              className="settings__language-label"
+              htmlFor="preferred-language"
+            >
+              {messages.settings.preferredLanguage}
+            </label>
+            <select
+              id="preferred-language"
+              className="settings__language-select"
+              aria-label={messages.settings.languageSelectAria}
+              value={locale}
+              onChange={(e) => {
+                void setLanguage(e.target.value as LocaleCode)
+              }}
+            >
+              {supportedLanguages.map((lang) => (
+                <option key={lang.code} value={lang.code}>
+                  {lang.nativeName}
+                </option>
+              ))}
+            </select>
+          </li>
           <li>
             <button
               className="settings__item"

--- a/src/components/SettingsButton/SettingsButton.test.tsx
+++ b/src/components/SettingsButton/SettingsButton.test.tsx
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SettingsButton } from './SettingsButton'
 import { verifyButtonContrast, mockComputedStyleForElement } from '../../test/utils/accessibility-helpers'
+import { renderWithLangReady } from '../../test/utils/renderWithLangReady'
 
 describe('SettingsButton', () => {
-  it('should render a button element', () => {
-    render(<SettingsButton onClick={() => {}} />)
+  it('should render a button element', async () => {
+    await renderWithLangReady(<SettingsButton onClick={() => {}} />)
 
     expect(screen.getByRole('button')).toBeInTheDocument()
   })
 
-  it('should display a gear icon', () => {
-    render(<SettingsButton onClick={() => {}} />)
+  it('should display a gear icon', async () => {
+    await renderWithLangReady(<SettingsButton onClick={() => {}} />)
 
     const button = screen.getByRole('button')
     const icon = button.querySelector('svg')
@@ -20,17 +21,20 @@ describe('SettingsButton', () => {
     expect(icon).toHaveAttribute('aria-hidden', 'true')
   })
 
-  it('should have accessible aria-label', () => {
-    render(<SettingsButton onClick={() => {}} />)
+  it('should have accessible aria-label', async () => {
+    await renderWithLangReady(<SettingsButton onClick={() => {}} />)
 
-    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Open settings')
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Open settings'
+    )
   })
 
   it('should call onClick when clicked', async () => {
     const user = userEvent.setup()
     const handleClick = vi.fn()
 
-    render(<SettingsButton onClick={handleClick} />)
+    await renderWithLangReady(<SettingsButton onClick={handleClick} />)
 
     await user.click(screen.getByRole('button'))
 
@@ -47,14 +51,14 @@ describe('SettingsButton', () => {
       }
     })
 
-    it('should have sufficient contrast ratio', () => {
+    it('should have sufficient contrast ratio', async () => {
       cleanup = mockComputedStyleForElement(
         'settings-button',
         'rgb(102, 102, 102)',
         'rgb(255, 255, 255)'
       )
 
-      render(<SettingsButton onClick={() => {}} />)
+      await renderWithLangReady(<SettingsButton onClick={() => {}} />)
 
       const button = screen.getByRole('button') as HTMLElement
       expect(verifyButtonContrast(button, 4.0)).toBe(true)

--- a/src/components/SettingsButton/SettingsButton.tsx
+++ b/src/components/SettingsButton/SettingsButton.tsx
@@ -1,5 +1,5 @@
 import { Settings } from 'lucide-react'
-import { messages } from '../../locale'
+import { useLanguage } from '../../contexts/LanguageContext'
 import './SettingsButton.css'
 
 interface SettingsButtonProps {
@@ -7,6 +7,7 @@ interface SettingsButtonProps {
 }
 
 export function SettingsButton({ onClick }: SettingsButtonProps) {
+  const { messages } = useLanguage()
   return (
     <button
       className="settings-button"

--- a/src/components/error/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/error/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { ErrorBoundary } from './ErrorBoundary'
+import { LanguageProvider } from '../../../contexts/LanguageContext'
 import { ReactError } from '../../../utils/error/errorTypes'
 import { logError } from '../../../utils/error/errorLogger'
+import { renderWithLangReady } from '../../../test/utils/renderWithLangReady'
 
 vi.mock('../../../utils/error/errorLogger', () => ({
   logError: vi.fn(),
@@ -16,8 +18,8 @@ describe('ErrorBoundary', () => {
     }
   })
 
-  it('should render children when there is no error', () => {
-    render(
+  it('should render children when there is no error', async () => {
+    await renderWithLangReady(
       <ErrorBoundary>
         <div>Test Content</div>
       </ErrorBoundary>
@@ -26,91 +28,101 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Test Content')).toBeInTheDocument()
   })
 
-  it('should catch errors and display ErrorFallback', () => {
+  it('should catch errors and display ErrorFallback', async () => {
     const ThrowError = () => {
       throw new Error('Test error')
     }
 
-    render(
+    await renderWithLangReady(
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>
     )
 
-    expect(
-      screen.getByText('Something went wrong. Please refresh the page.')
-    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByText('Something went wrong. Please refresh the page.')
+      ).toBeInTheDocument()
+    })
   })
 
-  it('should log error when error occurs', () => {
+  it('should log error when error occurs', async () => {
     const ThrowError = () => {
       throw new Error('Test error')
     }
 
-    render(
+    await renderWithLangReady(
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>
     )
 
-    expect(logError).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalled()
+    })
     const callArgs = vi.mocked(logError).mock.calls[0]
     expect(callArgs?.[0]).toBeInstanceOf(ReactError)
     expect(callArgs?.[0].code).toBe('REACT_RENDER_ERROR')
   })
 
-  it('should include component stack in error context', () => {
+  it('should include component stack in error context', async () => {
     const ThrowError = () => {
       throw new Error('Test error')
     }
 
-    render(
+    await renderWithLangReady(
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>
     )
 
-    expect(logError).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalled()
+    })
     const callArgs = vi.mocked(logError).mock.calls[0]
     expect(callArgs?.[1]).toHaveProperty('componentStack')
   })
 
-  it('should convert non-Error exceptions to ReactError', () => {
+  it('should convert non-Error exceptions to ReactError', async () => {
     const ThrowString = () => {
       throw 'String error'
     }
 
-    render(
+    await renderWithLangReady(
       <ErrorBoundary>
         <ThrowString />
       </ErrorBoundary>
     )
 
-    expect(logError).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalled()
+    })
     const callArgs = vi.mocked(logError).mock.calls[0]
     expect(callArgs?.[0]).toBeInstanceOf(ReactError)
-    expect(callArgs?.[0].userMessage).toBe('Something went wrong. Please refresh the page.')
+    expect(callArgs?.[0].userMessage).toBe(
+      'Something went wrong. Please refresh the page.'
+    )
   })
 
-  it('should store error in sessionStorage', () => {
+  it('should store error in sessionStorage', async () => {
     const ThrowError = () => {
       throw new Error('Test error')
     }
 
-    render(
+    await renderWithLangReady(
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>
     )
 
-    // Verify logError was called, which will store the error
-    // (storage integration is tested separately in errorLogger.test.ts)
-    expect(logError).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalled()
+    })
     const callArgs = vi.mocked(logError).mock.calls[0]
     expect(callArgs?.[0].code).toBe('REACT_RENDER_ERROR')
   })
 
-  it('should handle multiple errors', () => {
+  it('should handle multiple errors', async () => {
     const ThrowError1 = () => {
       throw new Error('Error 1')
     }
@@ -118,21 +130,30 @@ describe('ErrorBoundary', () => {
       throw new Error('Error 2')
     }
 
-    const { rerender } = render(
+    const { rerender } = await renderWithLangReady(
       <ErrorBoundary>
         <ThrowError1 />
       </ErrorBoundary>
     )
 
-    expect(screen.getByText('Something went wrong. Please refresh the page.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByText('Something went wrong. Please refresh the page.')
+      ).toBeInTheDocument()
+    })
 
     rerender(
-      <ErrorBoundary>
-        <ThrowError2 />
-      </ErrorBoundary>
+      <LanguageProvider>
+        <ErrorBoundary>
+          <ThrowError2 />
+        </ErrorBoundary>
+      </LanguageProvider>
     )
 
-    expect(screen.getByText('Something went wrong. Please refresh the page.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByText('Something went wrong. Please refresh the page.')
+      ).toBeInTheDocument()
+    })
   })
 })
-

--- a/src/components/error/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary/ErrorBoundary.tsx
@@ -1,11 +1,12 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react'
-import { messages } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import { ReactError, createAppError } from '../../../utils/error/errorTypes'
 import { logError } from '../../../utils/error/errorLogger'
 import { ErrorFallback } from '../ErrorFallback/ErrorFallback'
 
-interface ErrorBoundaryProps {
+interface ErrorBoundaryInnerProps {
   children: ReactNode
+  reactRenderErrorMessage: string
 }
 
 interface ErrorBoundaryState {
@@ -13,44 +14,49 @@ interface ErrorBoundaryState {
   error: ReactError | null
 }
 
-export class ErrorBoundary extends Component<
-  ErrorBoundaryProps,
+function buildReactError(
+  reactRenderErrorMessage: string,
+  error: unknown,
+  errorInfo?: ErrorInfo
+): ReactError {
+  const appError = createAppError(
+    error,
+    'REACT_RENDER_ERROR',
+    reactRenderErrorMessage,
+    errorInfo
+      ? {
+          componentStack: errorInfo.componentStack,
+        }
+      : undefined
+  )
+  return new ReactError(
+    appError.code as 'REACT_RENDER_ERROR',
+    appError.userMessage,
+    appError.technicalDetails,
+    appError.context
+  )
+}
+
+class ErrorBoundaryInner extends Component<
+  ErrorBoundaryInnerProps,
   ErrorBoundaryState
 > {
-  constructor(props: ErrorBoundaryProps) {
+  constructor(props: ErrorBoundaryInnerProps) {
     super(props)
     this.state = { hasError: false, error: null }
   }
 
-  private static createReactError(
-    error: unknown,
-    errorInfo?: ErrorInfo
-  ): ReactError {
-    const appError = createAppError(
+  static getDerivedStateFromError(): Partial<ErrorBoundaryState> {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+    const reactError = buildReactError(
+      this.props.reactRenderErrorMessage,
       error,
-      'REACT_RENDER_ERROR',
-      messages.errorBoundary.reactRenderError,
       errorInfo
-        ? {
-            componentStack: errorInfo.componentStack,
-          }
-        : undefined
     )
-    return new ReactError(
-      appError.code as 'REACT_RENDER_ERROR',
-      appError.userMessage,
-      appError.technicalDetails,
-      appError.context
-    )
-  }
-
-  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
-    const reactError = ErrorBoundary.createReactError(error)
-    return { hasError: true, error: reactError }
-  }
-
-  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    const reactError = ErrorBoundary.createReactError(error, errorInfo)
+    this.setState({ error: reactError })
     logError(reactError, { componentStack: errorInfo.componentStack })
   }
 
@@ -58,8 +64,24 @@ export class ErrorBoundary extends Component<
     if (this.state.hasError && this.state.error) {
       return <ErrorFallback error={this.state.error} />
     }
+    if (this.state.hasError) {
+      return null
+    }
     return this.props.children
   }
 }
 
+interface ErrorBoundaryProps {
+  children: ReactNode
+}
 
+export function ErrorBoundary({ children }: ErrorBoundaryProps) {
+  const { messages } = useLanguage()
+  return (
+    <ErrorBoundaryInner
+      reactRenderErrorMessage={messages.errorBoundary.reactRenderError}
+    >
+      {children}
+    </ErrorBoundaryInner>
+  )
+}

--- a/src/components/error/ErrorFallback/ErrorFallback.test.tsx
+++ b/src/components/error/ErrorFallback/ErrorFallback.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { ErrorFallback } from './ErrorFallback'
 import { AppError, IndexedDBError, ReactError } from '../../../utils/error/errorTypes'
+import { renderWithLangReady } from '../../../test/utils/renderWithLangReady'
 
 describe('ErrorFallback', () => {
   beforeEach(() => {
-    // Mock window.location.reload
     Object.defineProperty(window, 'location', {
       writable: true,
       value: { reload: vi.fn() },
@@ -16,56 +16,56 @@ describe('ErrorFallback', () => {
     vi.restoreAllMocks()
   })
 
-  it('should render error message', () => {
+  it('should render error message', async () => {
     const error = new AppError('UNKNOWN_ERROR', 'Test error message')
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     expect(screen.getByText('Test error message')).toBeInTheDocument()
   })
 
-  it('should have proper accessibility attributes', () => {
+  it('should have proper accessibility attributes', async () => {
     const error = new AppError('UNKNOWN_ERROR', 'Test error message')
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     const container = screen.getByRole('alert')
     expect(container).toHaveAttribute('aria-live', 'assertive')
   })
 
-  it('should display IndexedDBError message', () => {
+  it('should display IndexedDBError message', async () => {
     const error = new IndexedDBError(
       'INDEXEDDB_OPEN_FAILED',
       'Unable to access storage. Please refresh the page.'
     )
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     expect(
       screen.getByText('Unable to access storage. Please refresh the page.')
     ).toBeInTheDocument()
   })
 
-  it('should display ReactError message', () => {
+  it('should display ReactError message', async () => {
     const error = new ReactError(
       'REACT_RENDER_ERROR',
       'Something went wrong. Please refresh the page.'
     )
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     expect(
       screen.getByText('Something went wrong. Please refresh the page.')
     ).toBeInTheDocument()
   })
 
-  it('should render reload button', () => {
+  it('should render reload button', async () => {
     const error = new AppError('UNKNOWN_ERROR', 'Test error message')
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     const button = screen.getByRole('button', { name: /reload page/i })
     expect(button).toBeInTheDocument()
   })
 
-  it('should reload page when reload button is clicked', () => {
+  it('should reload page when reload button is clicked', async () => {
     const error = new AppError('UNKNOWN_ERROR', 'Test error message')
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     const button = screen.getByRole('button', { name: /reload page/i })
     button.click()
@@ -73,13 +73,12 @@ describe('ErrorFallback', () => {
     expect(window.location.reload).toHaveBeenCalledTimes(1)
   })
 
-  it('should focus the container when mounted', () => {
+  it('should focus the container when mounted', async () => {
     const error = new AppError('UNKNOWN_ERROR', 'Test error message')
-    render(<ErrorFallback error={error} />)
+    await renderWithLangReady(<ErrorFallback error={error} />)
 
     const alertContainer = screen.getByRole('alert')
     expect(alertContainer).toHaveAttribute('tabIndex', '-1')
     expect(alertContainer).toBe(document.activeElement)
   })
 })
-

--- a/src/components/error/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/error/ErrorFallback/ErrorFallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { messages } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import type { AppError } from '../../../utils/error/errorTypes'
 import './ErrorFallback.css'
 
@@ -8,6 +8,7 @@ interface ErrorFallbackProps {
 }
 
 export function ErrorFallback({ error }: ErrorFallbackProps) {
+  const { messages } = useLanguage()
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/src/components/habit/AnnualCalendar/AnnualCalendar.test.tsx
+++ b/src/components/habit/AnnualCalendar/AnnualCalendar.test.tsx
@@ -1,8 +1,24 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render } from '@testing-library/react'
 import { AnnualCalendar } from './AnnualCalendar'
 import { createMockHabit } from '../../../test/fixtures/habits'
 import { createDateString } from '../../../test/utils/date-helpers'
+import * as localeModule from '../../../locale'
+import { supportedLanguages } from '../../../config/supportedLanguages'
+
+vi.mock('../../../contexts/LanguageContext', () => ({
+  LanguageProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useLanguage: () => ({
+    locale: 'en' as const,
+    messages: localeModule.getMessagesForLocale('en'),
+    setLanguage: vi.fn(),
+    supportedLanguages,
+    isReady: true,
+  }),
+}))
 
 describe('AnnualCalendar', () => {
   beforeEach(() => {

--- a/src/components/habit/AnnualCalendar/AnnualCalendar.tsx
+++ b/src/components/habit/AnnualCalendar/AnnualCalendar.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
-import { messages, formatMessage } from '../../../locale'
+import { formatMessage } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import { getYearGrid, getDateString, isDateCompleted } from '../../../utils/date/annualCalendarHelpers'
 import { getTodayLocalDateString } from '../../../utils/date/dateHelpers'
 import type { Habit } from '../../../types/habit'
@@ -10,6 +11,7 @@ interface AnnualCalendarProps {
 }
 
 export function AnnualCalendar({ habit }: AnnualCalendarProps) {
+  const { messages } = useLanguage()
   const currentYear = new Date().getFullYear()
   const today = getTodayLocalDateString()
 

--- a/src/components/habit/HabitForm/HabitForm.tsx
+++ b/src/components/habit/HabitForm/HabitForm.tsx
@@ -1,8 +1,8 @@
 import { useState, FormEvent, useEffect, useRef } from 'react'
 import { useHabits } from '../../../contexts/HabitContext'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import { addHabit, updateHabit } from '../../../services/indexedDB'
 import { track } from '../../../analytics/umami'
-import { messages } from '../../../locale'
 import type { Habit } from '../../../types/habit'
 import { MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from '../../../utils/validation/validateHabit'
 import { StackingHabitsSelector } from '../StackingHabitsSelector/StackingHabitsSelector'
@@ -17,6 +17,7 @@ interface HabitFormProps {
 }
 
 export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
+  const { messages } = useLanguage()
   const { habits, refreshHabits } = useHabits()
   const [name, setName] = useState(habit?.name || '')
   const [description, setDescription] = useState(habit?.description || '')

--- a/src/components/habit/HabitList/HabitList.tsx
+++ b/src/components/habit/HabitList/HabitList.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useHabits } from '../../../contexts/HabitContext'
-import { messages, formatMessage } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
+import { formatMessage } from '../../../locale'
 import { calculateStreak } from '../../../utils/habit/calculateStreak'
 import { isTodayCompleted } from '../../../utils/habit/isTodayCompleted'
 import { getHabitsToPersistAfterStackingToggle } from '../../../utils/habit/stackingCompletionCoordinator'
@@ -16,6 +17,7 @@ interface HabitListProps {
 }
 
 export function HabitList({ onEdit }: HabitListProps) {
+  const { messages } = useLanguage()
   const { habits, isLoading, error, toggleHabitCompletion, updateHabit, deleteHabit } = useHabits()
   const [togglingId, setTogglingId] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)

--- a/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.test.tsx
+++ b/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.test.tsx
@@ -1,7 +1,23 @@
+import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { HabitStackingAccordion } from './HabitStackingAccordion'
+import * as localeModule from '../../../locale'
+import { supportedLanguages } from '../../../config/supportedLanguages'
+
+vi.mock('../../../contexts/LanguageContext', () => ({
+  LanguageProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useLanguage: () => ({
+    locale: 'en' as const,
+    messages: localeModule.getMessagesForLocale('en'),
+    setLanguage: vi.fn(),
+    supportedLanguages,
+    isReady: true,
+  }),
+}))
 import { createMockHabit } from '../../../test/fixtures/habits'
 import { createDateString } from '../../../test/utils/date-helpers'
 

--- a/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.tsx
+++ b/src/components/habit/HabitStackingAccordion/HabitStackingAccordion.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react'
-import { messages, formatMessage } from '../../../locale'
+import { formatMessage } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import { isTodayCompleted } from '../../../utils/habit/isTodayCompleted'
 import { isStackingHabitCompletedToday } from '../../../utils/habit/isStackingHabitCompletedToday'
 import { removeStackingHabit } from '../../../utils/habit/removeStackingHabit'
@@ -21,6 +22,7 @@ export function HabitStackingAccordion({
   onToggleStackingHabit,
   updateHabit,
 }: HabitStackingAccordionProps) {
+  const { messages } = useLanguage()
   const [expanded, setExpanded] = useState(false)
   const [togglingStackingId, setTogglingStackingId] = useState<string | null>(null)
   const [removalPending, setRemovalPending] = useState<{ stackingHabitId: string; displayName: string } | null>(null)

--- a/src/components/habit/StackingHabitsSelector/StackingHabitsSelector.test.tsx
+++ b/src/components/habit/StackingHabitsSelector/StackingHabitsSelector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, within, waitFor, render } from '@testing-library/react'
+import { screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'react'
 import { StackingHabitsSelector } from './StackingHabitsSelector'
@@ -7,7 +7,7 @@ import { renderWithProviders } from '../../../test/utils/render-helpers'
 import { createMockHabit } from '../../../test/fixtures/habits'
 
 function renderSelector(props: ComponentProps<typeof StackingHabitsSelector>) {
-  return render(<StackingHabitsSelector {...props} />)
+  return renderWithProviders(<StackingHabitsSelector {...props} />)
 }
 
 describe('StackingHabitsSelector', () => {

--- a/src/components/habit/StackingHabitsSelector/StackingHabitsSelector.tsx
+++ b/src/components/habit/StackingHabitsSelector/StackingHabitsSelector.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react'
-import { messages, formatMessage } from '../../../locale'
+import { formatMessage } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import { wouldCreateStackingCycle } from '../../../utils/habit/wouldCreateStackingCycle'
 import type { Habit } from '../../../types/habit'
 import './StackingHabitsSelector.css'
@@ -23,6 +24,7 @@ export function StackingHabitsSelector({
   disabled = false,
   id = 'stacking-habits-selector',
 }: StackingHabitsSelectorProps) {
+  const { messages } = useLanguage()
   const [filterText, setFilterText] = useState('')
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(0)

--- a/src/components/habit/StreakBadge/StreakBadge.test.tsx
+++ b/src/components/habit/StreakBadge/StreakBadge.test.tsx
@@ -1,6 +1,22 @@
+import React from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { StreakBadge } from './StreakBadge'
+import * as localeModule from '../../../locale'
+import { supportedLanguages } from '../../../config/supportedLanguages'
+
+vi.mock('../../../contexts/LanguageContext', () => ({
+  LanguageProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useLanguage: () => ({
+    locale: 'en' as const,
+    messages: localeModule.getMessagesForLocale('en'),
+    setLanguage: vi.fn(),
+    supportedLanguages,
+    isReady: true,
+  }),
+}))
 import {
   setupIntersectionObserverMock,
   teardownIntersectionObserverMock,

--- a/src/components/habit/StreakBadge/StreakBadge.tsx
+++ b/src/components/habit/StreakBadge/StreakBadge.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { messages, formatMessage } from '../../../locale'
+import { formatMessage } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import './StreakBadge.css'
 
 const COLORFUL_STREAK_THRESHOLD = 7
@@ -9,6 +10,7 @@ interface StreakBadgeProps {
 }
 
 export function StreakBadge({ streak }: StreakBadgeProps) {
+  const { messages } = useLanguage()
   const badgeRef = useRef<HTMLSpanElement>(null)
   const [hasAnimated, setHasAnimated] = useState(false)
 

--- a/src/components/modal/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/modal/ConfirmationModal/ConfirmationModal.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { render } from '@testing-library/react'
 import { ConfirmationModal } from './ConfirmationModal'
 import { verifyButtonContrast, mockComputedStyleForElement } from '../../../test/utils/accessibility-helpers'
+import { renderWithLangReady } from '../../../test/utils/renderWithLangReady'
 
 type ButtonVariant = 'primary' | 'alert' | 'warning' | 'success'
 
@@ -22,26 +22,28 @@ describe('ConfirmationModal', () => {
     vi.clearAllMocks()
   })
 
-  it('should not render when isOpen is false', () => {
-    render(<ConfirmationModal {...defaultProps} isOpen={false} />)
+  it('should not render when isOpen is false', async () => {
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} isOpen={false} />
+    )
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('should render when isOpen is true', () => {
-    render(<ConfirmationModal {...defaultProps} />)
+  it('should render when isOpen is true', async () => {
+    await renderWithLangReady(<ConfirmationModal {...defaultProps} />)
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
   it.each([
     { prop: 'title', text: 'Confirm Delete' },
     { prop: 'message', text: 'Are you sure you want to delete this item?' },
-  ])('should display $prop', ({ text }) => {
-    render(<ConfirmationModal {...defaultProps} />)
+  ])('should display $prop', async ({ text }) => {
+    await renderWithLangReady(<ConfirmationModal {...defaultProps} />)
     expect(screen.getByText(text)).toBeInTheDocument()
   })
 
-  it('should display confirm and cancel buttons', () => {
-    render(<ConfirmationModal {...defaultProps} />)
+  it('should display confirm and cancel buttons', async () => {
+    await renderWithLangReady(<ConfirmationModal {...defaultProps} />)
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
@@ -49,7 +51,9 @@ describe('ConfirmationModal', () => {
   it('should call onConfirm when confirm button is clicked', async () => {
     const user = userEvent.setup()
     const onConfirm = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onConfirm={onConfirm} />)
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} onConfirm={onConfirm} />
+    )
 
     const confirmButton = screen.getByRole('button', { name: 'Delete' })
     await user.click(confirmButton)
@@ -60,7 +64,9 @@ describe('ConfirmationModal', () => {
   it('should call onCancel when cancel button is clicked', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onCancel={onCancel} />)
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} onCancel={onCancel} />
+    )
 
     const cancelButton = screen.getByRole('button', { name: 'Cancel' })
     await user.click(cancelButton)
@@ -71,7 +77,9 @@ describe('ConfirmationModal', () => {
   it('should call onCancel when backdrop is clicked', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onCancel={onCancel} />)
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} onCancel={onCancel} />
+    )
 
     const backdrop = screen.getByRole('dialog').parentElement
     if (backdrop) {
@@ -83,7 +91,9 @@ describe('ConfirmationModal', () => {
   it('should not call onCancel when modal content is clicked', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onCancel={onCancel} />)
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} onCancel={onCancel} />
+    )
 
     const modalContent = screen.getByRole('dialog')
     await user.click(modalContent)
@@ -94,7 +104,9 @@ describe('ConfirmationModal', () => {
   it('should call onCancel when Escape key is pressed', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onCancel={onCancel} />)
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} onCancel={onCancel} />
+    )
 
     await user.keyboard('{Escape}')
 
@@ -104,7 +116,13 @@ describe('ConfirmationModal', () => {
   it('should not call onCancel when Escape is pressed if isConfirming is true', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onCancel={onCancel} isConfirming={true} />)
+    await renderWithLangReady(
+      <ConfirmationModal
+        {...defaultProps}
+        onCancel={onCancel}
+        isConfirming={true}
+      />
+    )
 
     await user.keyboard('{Escape}')
 
@@ -114,7 +132,13 @@ describe('ConfirmationModal', () => {
   it('should not call onCancel when backdrop is clicked if isConfirming is true', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    render(<ConfirmationModal {...defaultProps} onCancel={onCancel} isConfirming={true} />)
+    await renderWithLangReady(
+      <ConfirmationModal
+        {...defaultProps}
+        onCancel={onCancel}
+        isConfirming={true}
+      />
+    )
 
     const backdrop = screen.getByRole('dialog').parentElement
     if (backdrop) {
@@ -123,27 +147,31 @@ describe('ConfirmationModal', () => {
     }
   })
 
-  it('should have proper ARIA attributes', () => {
-    render(<ConfirmationModal {...defaultProps} />)
+  it('should have proper ARIA attributes', async () => {
+    await renderWithLangReady(<ConfirmationModal {...defaultProps} />)
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveAttribute('aria-modal', 'true')
     expect(dialog).toHaveAttribute('aria-labelledby')
   })
 
-  it('should use custom confirm and cancel labels', () => {
-    render(
+  it('should use custom confirm and cancel labels', async () => {
+    await renderWithLangReady(
       <ConfirmationModal
         {...defaultProps}
         confirmLabel="Yes, delete it"
         cancelLabel="No, keep it"
       />
     )
-    expect(screen.getByRole('button', { name: 'Yes, delete it' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'No, keep it' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Yes, delete it' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'No, keep it' })
+    ).toBeInTheDocument()
   })
 
-  it('should use default labels when not provided', () => {
-    render(
+  it('should use default labels when not provided', async () => {
+    await renderWithLangReady(
       <ConfirmationModal
         isOpen={true}
         title="Test"
@@ -156,8 +184,10 @@ describe('ConfirmationModal', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
   })
 
-  it('should disable buttons when isConfirming is true', () => {
-    render(<ConfirmationModal {...defaultProps} isConfirming={true} />)
+  it('should disable buttons when isConfirming is true', async () => {
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} isConfirming={true} />
+    )
     const confirmButton = screen.getByRole('button', { name: /processing/i })
     const cancelButton = screen.getByRole('button', { name: 'Cancel' })
 
@@ -165,14 +195,16 @@ describe('ConfirmationModal', () => {
     expect(cancelButton).toBeDisabled()
   })
 
-  it('should show default loading state on confirm button when isConfirming is true', () => {
-    render(<ConfirmationModal {...defaultProps} isConfirming={true} />)
+  it('should show default loading state on confirm button when isConfirming is true', async () => {
+    await renderWithLangReady(
+      <ConfirmationModal {...defaultProps} isConfirming={true} />
+    )
     const confirmButton = screen.getByRole('button', { name: /processing/i })
     expect(confirmButton).toBeInTheDocument()
   })
 
-  it('should show custom confirmingLabel when isConfirming is true', () => {
-    render(
+  it('should show custom confirmingLabel when isConfirming is true', async () => {
+    await renderWithLangReady(
       <ConfirmationModal
         {...defaultProps}
         isConfirming={true}
@@ -183,8 +215,8 @@ describe('ConfirmationModal', () => {
     expect(confirmButton).toBeInTheDocument()
   })
 
-  it('should use alert button variant by default', () => {
-    render(<ConfirmationModal {...defaultProps} />)
+  it('should use alert button variant by default', async () => {
+    await renderWithLangReady(<ConfirmationModal {...defaultProps} />)
     const confirmButton = screen.getByRole('button', { name: 'Delete' })
     expect(confirmButton).toHaveClass('confirmation-modal-button-alert')
   })
@@ -193,11 +225,19 @@ describe('ConfirmationModal', () => {
     { variant: 'primary', expectedClass: 'confirmation-modal-button-primary' },
     { variant: 'warning', expectedClass: 'confirmation-modal-button-warning' },
     { variant: 'success', expectedClass: 'confirmation-modal-button-success' },
-  ])('should apply $variant button variant when specified', ({ variant, expectedClass }) => {
-    render(<ConfirmationModal {...defaultProps} buttonVariant={variant as ButtonVariant} />)
-    const confirmButton = screen.getByRole('button', { name: 'Delete' })
-    expect(confirmButton).toHaveClass(expectedClass)
-  })
+  ])(
+    'should apply $variant button variant when specified',
+    async ({ variant, expectedClass }) => {
+      await renderWithLangReady(
+        <ConfirmationModal
+          {...defaultProps}
+          buttonVariant={variant as ButtonVariant}
+        />
+      )
+      const confirmButton = screen.getByRole('button', { name: 'Delete' })
+      expect(confirmButton).toHaveClass(expectedClass)
+    }
+  )
 
   describe('Accessibility - Contrast', () => {
     let cleanup: (() => void) | undefined
@@ -214,21 +254,24 @@ describe('ConfirmationModal', () => {
       { variant: 'alert', bgColor: 'rgb(211, 47, 47)', minRatio: 4.0 },
       { variant: 'warning', bgColor: 'rgb(230, 81, 0)', minRatio: 4.5 },
       { variant: 'success', bgColor: 'rgb(46, 125, 50)', minRatio: 4.0 },
-    ])('should have sufficient contrast for $variant button', ({ variant, bgColor, minRatio }) => {
-      cleanup = mockComputedStyleForElement(
-        `confirmation-modal-button-${variant}`,
-        'rgb(0, 0, 0)',
-        bgColor
-      )
+    ])(
+      'should have sufficient contrast for $variant button',
+      async ({ variant, bgColor, minRatio }) => {
+        cleanup = mockComputedStyleForElement(
+          `confirmation-modal-button-${variant}`,
+          'rgb(0, 0, 0)',
+          bgColor
+        )
 
-      render(
-        <ConfirmationModal
-          {...defaultProps}
-          buttonVariant={variant as ButtonVariant}
-        />
-      )
-      const confirmButton = screen.getByRole('button', { name: 'Delete' })
-      expect(verifyButtonContrast(confirmButton, minRatio)).toBe(true)
-    })
+        await renderWithLangReady(
+          <ConfirmationModal
+            {...defaultProps}
+            buttonVariant={variant as ButtonVariant}
+          />
+        )
+        const confirmButton = screen.getByRole('button', { name: 'Delete' })
+        expect(verifyButtonContrast(confirmButton, minRatio)).toBe(true)
+      }
+    )
   })
 })

--- a/src/components/modal/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/modal/ConfirmationModal/ConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import { useId } from 'react'
-import { messages } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import { Modal } from '../Modal/Modal'
 import '../Modal/Modal.css'
 import './ConfirmationModal.css'
@@ -23,15 +23,20 @@ export function ConfirmationModal({
   isOpen,
   title,
   message,
-  confirmLabel = messages.confirmationModal.defaultConfirm,
-  cancelLabel = messages.confirmationModal.defaultCancel,
+  confirmLabel,
+  cancelLabel,
   confirmingLabel,
   buttonVariant = 'alert',
   onConfirm,
   onCancel,
   isConfirming = false,
 }: ConfirmationModalProps) {
+  const { messages } = useLanguage()
   const messageId = useId()
+  const resolvedConfirmLabel =
+    confirmLabel ?? messages.confirmationModal.defaultConfirm
+  const resolvedCancelLabel =
+    cancelLabel ?? messages.confirmationModal.defaultCancel
   return (
     <Modal
       isOpen={isOpen}
@@ -51,7 +56,7 @@ export function ConfirmationModal({
           onClick={onCancel}
           disabled={isConfirming}
         >
-          {cancelLabel}
+          {resolvedCancelLabel}
         </button>
         <button
           type="button"
@@ -59,7 +64,9 @@ export function ConfirmationModal({
           onClick={onConfirm}
           disabled={isConfirming}
         >
-          {isConfirming ? (confirmingLabel ?? messages.confirmationModal.defaultProcessing) : confirmLabel}
+          {isConfirming
+            ? confirmingLabel ?? messages.confirmationModal.defaultProcessing
+            : resolvedConfirmLabel}
         </button>
       </div>
     </Modal>

--- a/src/components/pwa/InstallPrompt/InstallPrompt.test.tsx
+++ b/src/components/pwa/InstallPrompt/InstallPrompt.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, waitFor, act } from '@testing-library/react'
-import { render } from '@testing-library/react'
 import { InstallPrompt } from './InstallPrompt'
+import { renderWithLangReady } from '../../../test/utils/renderWithLangReady'
 import type { BeforeInstallPromptEvent } from '../../../types/pwa'
 import { verifyButtonContrast } from '../../../test/utils/accessibility-helpers'
 
@@ -53,7 +53,7 @@ describe('InstallPrompt', () => {
     vi.restoreAllMocks()
   })
 
-  it('should not render when app is already installed', () => {
+  it('should not render when app is already installed', async () => {
     window.matchMedia = vi.fn().mockImplementation((query: string) => {
       if (query === '(display-mode: standalone)') {
         return {
@@ -79,19 +79,19 @@ describe('InstallPrompt', () => {
       }
     })
 
-    render(<InstallPrompt />)
+    await renderWithLangReady(<InstallPrompt />)
 
     expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument()
   })
 
-  it('should not render when beforeinstallprompt event is not fired', () => {
-    render(<InstallPrompt />)
+  it('should not render when beforeinstallprompt event is not fired', async () => {
+    await renderWithLangReady(<InstallPrompt />)
 
     expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument()
   })
 
   it('should render install button when beforeinstallprompt event is fired', async () => {
-    render(<InstallPrompt />)
+    await renderWithLangReady(<InstallPrompt />)
 
     const event = createBeforeInstallPromptEvent(mockPrompt, mockUserChoice)
 
@@ -105,7 +105,7 @@ describe('InstallPrompt', () => {
   })
 
   it('should call prompt when install button is clicked', async () => {
-    render(<InstallPrompt />)
+    await renderWithLangReady(<InstallPrompt />)
 
     const event = createBeforeInstallPromptEvent(mockPrompt, mockUserChoice)
 
@@ -126,7 +126,7 @@ describe('InstallPrompt', () => {
   })
 
   it('should hide install button after successful installation', async () => {
-    render(<InstallPrompt />)
+    await renderWithLangReady(<InstallPrompt />)
 
     const event = createBeforeInstallPromptEvent(
       mockPrompt,
@@ -153,7 +153,7 @@ describe('InstallPrompt', () => {
   })
 
   it('should hide install button when appinstalled event is fired', async () => {
-    render(<InstallPrompt />)
+    await renderWithLangReady(<InstallPrompt />)
 
     const event = createBeforeInstallPromptEvent(mockPrompt, mockUserChoice)
 
@@ -175,7 +175,7 @@ describe('InstallPrompt', () => {
   })
 
   it('should have proper accessibility attributes', async () => {
-    render(<InstallPrompt />)
+    await renderWithLangReady(<InstallPrompt />)
 
     const event = createBeforeInstallPromptEvent(mockPrompt, mockUserChoice)
 
@@ -210,7 +210,7 @@ describe('InstallPrompt', () => {
         return style
       }) as typeof window.getComputedStyle
 
-      render(<InstallPrompt />)
+      await renderWithLangReady(<InstallPrompt />)
 
       const event = createBeforeInstallPromptEvent(mockPrompt, mockUserChoice)
 

--- a/src/components/pwa/InstallPrompt/InstallPrompt.tsx
+++ b/src/components/pwa/InstallPrompt/InstallPrompt.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react'
 import { Download } from 'lucide-react'
-import { messages } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import './InstallPrompt.css'
 import type { BeforeInstallPromptEvent } from '../../../types/pwa'
 
 export function InstallPrompt() {
+  const { messages } = useLanguage()
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null)
   const [isInstalled, setIsInstalled] = useState(() => {
     if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) {

--- a/src/components/pwa/OfflineIndicator/OfflineIndicator.test.tsx
+++ b/src/components/pwa/OfflineIndicator/OfflineIndicator.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, waitFor, act } from '@testing-library/react'
-import { render } from '@testing-library/react'
 import { OfflineIndicator } from './OfflineIndicator'
 import { setNavigatorOnline, triggerNetworkEvent } from '../../../test/utils/navigator-test-helpers'
 import { getButtonContrastRatio } from '../../../test/utils/accessibility-helpers'
+import { renderWithLangReady } from '../../../test/utils/renderWithLangReady'
 
 describe('OfflineIndicator', () => {
   let originalOnLine: boolean
@@ -25,49 +25,52 @@ describe('OfflineIndicator', () => {
     vi.restoreAllMocks()
   })
 
-  it('should not render when device is online', () => {
+  it('should not render when device is online', async () => {
     setNavigatorOnline(true)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
     expect(screen.queryByText(/offline/i)).not.toBeInTheDocument()
   })
 
-  it('should render when device is offline', () => {
+  it('should render when device is offline', async () => {
     setNavigatorOnline(false)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     expect(screen.getByRole('status')).toBeInTheDocument()
     expect(screen.getByText('offline')).toBeInTheDocument()
   })
 
-  it('should display no-wifi icon when offline', () => {
+  it('should display no-wifi icon when offline', async () => {
     setNavigatorOnline(false)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     const statusElement = screen.getByRole('status')
     const icon = statusElement.querySelector('svg')
     expect(icon).toBeInTheDocument()
   })
 
-  it('should have proper accessibility attributes when offline', () => {
+  it('should have proper accessibility attributes when offline', async () => {
     setNavigatorOnline(false)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     const statusElement = screen.getByRole('status')
     expect(statusElement).toHaveAttribute('aria-live', 'polite')
     expect(statusElement).toHaveAttribute('aria-atomic', 'true')
-    expect(statusElement).toHaveAttribute('aria-label', 'Offline status indicator')
+    expect(statusElement).toHaveAttribute(
+      'aria-label',
+      'Offline status indicator'
+    )
   })
 
   it('should listen to online event and hide when device comes online', async () => {
     setNavigatorOnline(false)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     expect(screen.getByRole('status')).toBeInTheDocument()
 
@@ -84,7 +87,7 @@ describe('OfflineIndicator', () => {
   it('should listen to offline event and show when device goes offline', async () => {
     setNavigatorOnline(true)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
 
@@ -99,19 +102,19 @@ describe('OfflineIndicator', () => {
     })
   })
 
-  it('should add event listeners on mount', () => {
+  it('should add event listeners on mount', async () => {
     setNavigatorOnline(true)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     expect(addEventListenerSpy).toHaveBeenCalledWith('online', expect.any(Function))
     expect(addEventListenerSpy).toHaveBeenCalledWith('offline', expect.any(Function))
   })
 
-  it('should remove event listeners on unmount', () => {
+  it('should remove event listeners on unmount', async () => {
     setNavigatorOnline(true)
 
-    const { unmount } = render(<OfflineIndicator />)
+    const { unmount } = await renderWithLangReady(<OfflineIndicator />)
 
     unmount()
 
@@ -119,10 +122,10 @@ describe('OfflineIndicator', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith('offline', expect.any(Function))
   })
 
-  it('should accept custom className prop', () => {
+  it('should accept custom className prop', async () => {
     setNavigatorOnline(false)
 
-    render(<OfflineIndicator className="custom-class" />)
+    await renderWithLangReady(<OfflineIndicator className="custom-class" />)
 
     const statusElement = screen.getByRole('status')
     expect(statusElement).toHaveClass('custom-class')
@@ -131,7 +134,7 @@ describe('OfflineIndicator', () => {
   it('should update when online status changes multiple times', async () => {
     setNavigatorOnline(false)
 
-    render(<OfflineIndicator />)
+    await renderWithLangReady(<OfflineIndicator />)
 
     expect(screen.getByRole('status')).toBeInTheDocument()
 
@@ -164,7 +167,7 @@ describe('OfflineIndicator', () => {
   })
 
   describe('Accessibility - Contrast', () => {
-    it('should have sufficient contrast ratio for offline indicator', () => {
+    it('should have sufficient contrast ratio for offline indicator', async () => {
       setNavigatorOnline(false)
 
       const originalGetComputedStyle = window.getComputedStyle
@@ -185,14 +188,13 @@ describe('OfflineIndicator', () => {
         return style
       }) as typeof window.getComputedStyle
 
-      render(<OfflineIndicator />)
+      await renderWithLangReady(<OfflineIndicator />)
 
       const statusElement = screen.getByRole('status')
       const contrastRatio = getButtonContrastRatio(statusElement as HTMLElement)
       expect(contrastRatio).toBeGreaterThan(4.0)
-      
+
       window.getComputedStyle = originalGetComputedStyle
     })
   })
 })
-

--- a/src/components/pwa/OfflineIndicator/OfflineIndicator.tsx
+++ b/src/components/pwa/OfflineIndicator/OfflineIndicator.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { WifiOff } from 'lucide-react'
-import { messages } from '../../../locale'
+import { useLanguage } from '../../../contexts/LanguageContext'
 import './OfflineIndicator.css'
 
 interface OfflineIndicatorProps {
@@ -8,6 +8,7 @@ interface OfflineIndicatorProps {
 }
 
 export function OfflineIndicator({ className }: OfflineIndicatorProps) {
+  const { messages } = useLanguage()
   const [isOffline, setIsOffline] = useState(!globalThis.navigator.onLine)
 
   useEffect(() => {

--- a/src/config/supportedLanguages.ts
+++ b/src/config/supportedLanguages.ts
@@ -1,0 +1,22 @@
+import type { LocaleCode } from '../locale/types'
+
+export const supportedLanguages = [
+  { code: 'en' as const, name: 'English', nativeName: 'English' },
+  { code: 'pt-BR' as const, name: 'Portuguese', nativeName: 'Português' },
+] as const satisfies ReadonlyArray<{
+  code: LocaleCode
+  name: string
+  nativeName: string
+}>
+
+export type SupportedLanguageEntry = (typeof supportedLanguages)[number]
+
+export const SUPPORTED_LOCALES: readonly LocaleCode[] = supportedLanguages.map(
+  (l) => l.code
+)
+
+export const defaultLanguage: LocaleCode = 'en'
+
+export function isSupportedLocale(code: string): code is LocaleCode {
+  return (SUPPORTED_LOCALES as readonly string[]).includes(code)
+}

--- a/src/contexts/HabitContext.tsx
+++ b/src/contexts/HabitContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
-import { messages } from '../locale'
+import { useLanguage } from './LanguageContext'
 import { openDB, getAllHabits, updateHabit as updateHabitInDB, deleteHabit as deleteHabitFromDB } from '../services/indexedDB'
 import { toggleCompletion } from '../utils/habit/toggleCompletion'
 import { stripTodayFromAutoCompletedDates } from '../utils/habit/checkAutoCompletion'
@@ -32,6 +32,7 @@ interface HabitProviderProps {
 }
 
 export function HabitProvider({ children }: HabitProviderProps) {
+  const { messages } = useLanguage()
   const [habits, setHabits] = useState<Habit[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -51,7 +52,7 @@ export function HabitProvider({ children }: HabitProviderProps) {
       setError(appError.userMessage)
       throw err
     }
-  }, [])
+  }, [messages.app.loadHabitsError])
 
   const updateHabit = useCallback(async (habit: Habit) => {
     try {
@@ -68,7 +69,7 @@ export function HabitProvider({ children }: HabitProviderProps) {
       setError(appError.userMessage)
       throw err
     }
-  }, [refreshHabits])
+  }, [messages.app.updateHabitError, refreshHabits])
 
   const toggleHabitCompletion = useCallback(async (habitId: string) => {
     try {
@@ -91,7 +92,7 @@ export function HabitProvider({ children }: HabitProviderProps) {
       setError(appError.userMessage)
       throw err
     }
-  }, [habits, refreshHabits, updateHabit])
+  }, [habits, messages.app.toggleCompletionError, refreshHabits, updateHabit])
 
   const deleteHabit = useCallback(async (habitId: string) => {
     try {
@@ -108,7 +109,7 @@ export function HabitProvider({ children }: HabitProviderProps) {
       setError(appError.userMessage)
       throw err
     }
-  }, [refreshHabits])
+  }, [messages.app.deleteHabitError, refreshHabits])
 
   useEffect(() => {
     async function initializeApp() {
@@ -131,7 +132,7 @@ export function HabitProvider({ children }: HabitProviderProps) {
     }
 
     initializeApp()
-  }, [refreshHabits])
+  }, [messages.app.initError, refreshHabits])
 
   const value: HabitContextType = useMemo(
     () => ({

--- a/src/contexts/LanguageContext.test.tsx
+++ b/src/contexts/LanguageContext.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as languageStorage from '../services/languageStorage'
+import { LanguageProvider, useLanguage } from './LanguageContext'
+
+function LocaleConsumer() {
+  const { locale, messages, setLanguage } = useLanguage()
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <span data-testid="title">{messages.app.title}</span>
+      <button type="button" onClick={() => void setLanguage('pt-BR')}>
+        use-pt
+      </button>
+    </div>
+  )
+}
+
+describe('LanguageProvider', () => {
+  beforeEach(() => {
+    vi.mocked(languageStorage.getPreferredLanguage).mockResolvedValue('en')
+    vi.mocked(languageStorage.setPreferredLanguage).mockResolvedValue(undefined)
+  })
+
+  it('loads stored preference without persisting again', async () => {
+    vi.mocked(languageStorage.getPreferredLanguage).mockResolvedValue('pt-BR')
+
+    render(
+      <LanguageProvider>
+        <LocaleConsumer />
+      </LanguageProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale')).toHaveTextContent('pt-BR')
+    })
+    expect(languageStorage.setPreferredLanguage).not.toHaveBeenCalled()
+  })
+
+  it('persists device default on first visit when nothing stored', async () => {
+    vi.mocked(languageStorage.getPreferredLanguage).mockResolvedValue(undefined)
+
+    render(
+      <LanguageProvider>
+        <LocaleConsumer />
+      </LanguageProvider>
+    )
+
+    await waitFor(() => {
+      expect(languageStorage.setPreferredLanguage).toHaveBeenCalled()
+    })
+  })
+
+  it('setLanguage updates locale and persists', async () => {
+    const user = userEvent.setup()
+    vi.mocked(languageStorage.getPreferredLanguage).mockResolvedValue('en')
+
+    render(
+      <LanguageProvider>
+        <LocaleConsumer />
+      </LanguageProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale')).toHaveTextContent('en')
+    })
+
+    await user.click(screen.getByRole('button', { name: 'use-pt' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('locale')).toHaveTextContent('pt-BR')
+    })
+    expect(languageStorage.setPreferredLanguage).toHaveBeenCalledWith('pt-BR')
+  })
+})

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,142 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  defaultLanguage,
+  isSupportedLocale,
+  supportedLanguages,
+} from '../config/supportedLanguages'
+import type { LocaleCode } from '../locale/types'
+import { getMessagesForLocale } from '../locale'
+import { getDeviceLocale } from '../locale/defaultLocale'
+import {
+  getPreferredLanguage,
+  setPreferredLanguage as persistPreferredLanguage,
+} from '../services/languageStorage'
+
+const LOADING_LOCALE: LocaleCode = defaultLanguage
+
+interface LanguageContextValue {
+  locale: LocaleCode
+  messages: ReturnType<typeof getMessagesForLocale>
+  setLanguage: (locale: LocaleCode) => Promise<void>
+  supportedLanguages: typeof supportedLanguages
+  isReady: boolean
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined)
+
+export function useLanguage(): LanguageContextValue {
+  const ctx = useContext(LanguageContext)
+  if (ctx === undefined) {
+    throw new Error('useLanguage must be used within a LanguageProvider')
+  }
+  return ctx
+}
+
+interface LanguageProviderProps {
+  children: ReactNode
+  /** When set, skips IndexedDB and enables the provider synchronously (tests). */
+  initialLocale?: LocaleCode
+}
+
+export function LanguageProvider({
+  children,
+  initialLocale,
+}: LanguageProviderProps) {
+  const [locale, setLocaleState] = useState<LocaleCode>(
+    () => initialLocale ?? LOADING_LOCALE
+  )
+  const [isReady, setIsReady] = useState(() => initialLocale !== undefined)
+  const mountedRef = useRef(true)
+
+  const loadingMessages = useMemo(
+    () => getMessagesForLocale(LOADING_LOCALE),
+    []
+  )
+
+  useEffect(() => {
+    if (initialLocale !== undefined) {
+      document.documentElement.lang = initialLocale
+      return
+    }
+
+    mountedRef.current = true
+
+    async function init() {
+      try {
+        const stored = await getPreferredLanguage()
+        let next: LocaleCode
+        if (stored !== undefined) {
+          next = stored
+        } else {
+          next = getDeviceLocale()
+          await persistPreferredLanguage(next)
+        }
+        if (mountedRef.current) {
+          setLocaleState(next)
+          setIsReady(true)
+        }
+      } catch {
+        if (mountedRef.current) {
+          setLocaleState(defaultLanguage)
+          setIsReady(true)
+        }
+      }
+    }
+
+    void init()
+    return () => {
+      mountedRef.current = false
+    }
+  }, [initialLocale])
+
+  useEffect(() => {
+    if (isReady) {
+      document.documentElement.lang = locale
+    }
+  }, [locale, isReady])
+
+  const setLanguage = useCallback(async (code: string) => {
+    if (!isSupportedLocale(code)) return
+    setLocaleState(code)
+    await persistPreferredLanguage(code)
+  }, [])
+
+  const messages = useMemo(() => getMessagesForLocale(locale), [locale])
+
+  const value = useMemo(
+    (): LanguageContextValue => ({
+      locale,
+      messages,
+      setLanguage,
+      supportedLanguages,
+      isReady,
+    }),
+    [locale, messages, setLanguage, isReady]
+  )
+
+  if (!isReady) {
+    return (
+      <div className="app">
+        <header className="app-header">
+          <h1 className="app-header__logo">{loadingMessages.app.title}</h1>
+          <div role="status" aria-live="polite" aria-atomic="true">
+            <p>{loadingMessages.app.loading}</p>
+          </div>
+        </header>
+      </div>
+    )
+  }
+
+  return (
+    <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
+  )
+}

--- a/src/locale/defaultLocale.test.ts
+++ b/src/locale/defaultLocale.test.ts
@@ -1,7 +1,40 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { SUPPORTED_LOCALES } from './defaultLocale'
 
-describe('getDefaultLocale', () => {
+describe('normalizeNavigatorLanguageTag', () => {
+  let normalizeNavigatorLanguageTag: (raw: string) => 'en' | 'pt-BR'
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ normalizeNavigatorLanguageTag } = await import('./defaultLocale'))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('should return en for en language', () => {
+    expect(normalizeNavigatorLanguageTag('en')).toBe('en')
+  })
+
+  it('should return en for en-US', () => {
+    expect(normalizeNavigatorLanguageTag('en-US')).toBe('en')
+  })
+
+  it('should return en for unsupported language', () => {
+    expect(normalizeNavigatorLanguageTag('fr')).toBe('en')
+  })
+
+  it('should return pt-BR for pt-BR language', () => {
+    expect(normalizeNavigatorLanguageTag('pt-BR')).toBe('pt-BR')
+  })
+
+  it('should return pt-BR for pt language', () => {
+    expect(normalizeNavigatorLanguageTag('pt')).toBe('pt-BR')
+  })
+})
+
+describe('getDeviceLocale', () => {
   let originalNavigator: typeof navigator
 
   beforeEach(() => {
@@ -24,8 +57,8 @@ describe('getDefaultLocale', () => {
       writable: true,
       configurable: true,
     })
-    const { getDefaultLocale: getLocale } = await import('./defaultLocale')
-    expect(getLocale()).toBe('en')
+    const { getDeviceLocale } = await import('./defaultLocale')
+    expect(getDeviceLocale()).toBe('en')
   })
 
   it('should return en for en-US', async () => {
@@ -34,8 +67,8 @@ describe('getDefaultLocale', () => {
       writable: true,
       configurable: true,
     })
-    const { getDefaultLocale: getLocale } = await import('./defaultLocale')
-    expect(getLocale()).toBe('en')
+    const { getDeviceLocale } = await import('./defaultLocale')
+    expect(getDeviceLocale()).toBe('en')
   })
 
   it('should return en for unsupported language', async () => {
@@ -44,8 +77,8 @@ describe('getDefaultLocale', () => {
       writable: true,
       configurable: true,
     })
-    const { getDefaultLocale: getLocale } = await import('./defaultLocale')
-    expect(getLocale()).toBe('en')
+    const { getDeviceLocale } = await import('./defaultLocale')
+    expect(getDeviceLocale()).toBe('en')
   })
 
   it('should return en when navigator.languages is empty and language is unsupported', async () => {
@@ -54,8 +87,8 @@ describe('getDefaultLocale', () => {
       writable: true,
       configurable: true,
     })
-    const { getDefaultLocale: getLocale } = await import('./defaultLocale')
-    expect(getLocale()).toBe('en')
+    const { getDeviceLocale } = await import('./defaultLocale')
+    expect(getDeviceLocale()).toBe('en')
   })
 
   it('should return pt-BR for pt-BR language', async () => {
@@ -64,8 +97,8 @@ describe('getDefaultLocale', () => {
       writable: true,
       configurable: true,
     })
-    const { getDefaultLocale: getLocale } = await import('./defaultLocale')
-    expect(getLocale()).toBe('pt-BR')
+    const { getDeviceLocale } = await import('./defaultLocale')
+    expect(getDeviceLocale()).toBe('pt-BR')
   })
 
   it('should return pt-BR for pt language', async () => {
@@ -74,8 +107,8 @@ describe('getDefaultLocale', () => {
       writable: true,
       configurable: true,
     })
-    const { getDefaultLocale: getLocale } = await import('./defaultLocale')
-    expect(getLocale()).toBe('pt-BR')
+    const { getDeviceLocale } = await import('./defaultLocale')
+    expect(getDeviceLocale()).toBe('pt-BR')
   })
 })
 

--- a/src/locale/defaultLocale.ts
+++ b/src/locale/defaultLocale.ts
@@ -1,24 +1,17 @@
 import type { LocaleCode } from './types'
+export { SUPPORTED_LOCALES } from '../config/supportedLanguages'
 
-export const SUPPORTED_LOCALES: readonly LocaleCode[] = ['en', 'pt-BR']
-
-let cachedLocale: LocaleCode | null = null
-
-function normalizeToSupportedLocale(localeTag: string): LocaleCode {
-  const subtag = localeTag.split('-')[0]?.toLowerCase() ?? 'en'
+export function normalizeNavigatorLanguageTag(raw: string): LocaleCode {
+  const subtag = raw.split('-')[0]?.toLowerCase() ?? 'en'
   if (subtag === 'pt') return 'pt-BR'
   if (subtag === 'en') return 'en'
   return 'en'
 }
 
-export function getDefaultLocale(): LocaleCode {
-  if (cachedLocale !== null) {
-    return cachedLocale
-  }
+export function getDeviceLocale(): LocaleCode {
   const raw =
     typeof navigator !== 'undefined'
       ? navigator.languages?.[0] ?? navigator.language ?? 'en'
       : 'en'
-  cachedLocale = normalizeToSupportedLocale(String(raw))
-  return cachedLocale
+  return normalizeNavigatorLanguageTag(String(raw))
 }

--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -1,26 +1,14 @@
 import type { LocaleCode, LocaleMessages } from './types'
-import { getDefaultLocale } from './defaultLocale'
 import { formatMessage as formatMessageFn } from './formatMessage'
 import { en } from './messages/en'
 import { ptBR } from './messages/pt-BR'
 
-function getMessages(locale: LocaleCode): LocaleMessages {
+export function getMessagesForLocale(locale: LocaleCode): LocaleMessages {
   if (locale === 'pt-BR') {
     return ptBR
   }
   return en
 }
 
-let messagesCache: LocaleMessages | null = null
-
-export function getMessagesForApp(): LocaleMessages {
-  if (messagesCache === null) {
-    messagesCache = getMessages(getDefaultLocale())
-  }
-  return messagesCache
-}
-
-export const messages = getMessagesForApp()
 export const formatMessage = formatMessageFn
-export { getDefaultLocale }
 export type { LocaleCode, LocaleMessages }

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -130,6 +130,8 @@ export const en = {
   settings: {
     title: 'Settings',
     close: 'Close settings',
+    preferredLanguage: 'Preferred language',
+    languageSelectAria: 'Preferred language',
     items: {
       changelog: 'Changelog',
     },

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -131,6 +131,8 @@ export const ptBR = {
   settings: {
     title: 'Configurações',
     close: 'Fechar configurações',
+    preferredLanguage: 'Idioma preferido',
+    languageSelectAria: 'Idioma preferido',
     items: {
       changelog: 'Registro de alterações',
     },

--- a/src/services/indexedDB.test.ts
+++ b/src/services/indexedDB.test.ts
@@ -102,6 +102,9 @@ describe('IndexedDB Service', () => {
     it('opens database and creates object store if it does not exist', async () => {
       const mockOpenRequest = createMockRequest()
       mockOpenRequest.result = mockDB
+      const createObjectStore = vi.fn().mockReturnValue({
+        createIndex: vi.fn(),
+      })
 
       ;(mockIndexedDB.open as ReturnType<typeof vi.fn>).mockReturnValue(mockOpenRequest)
 
@@ -114,9 +117,7 @@ describe('IndexedDB Service', () => {
           target: {
             result: {
               objectStoreNames: { contains: () => false },
-              createObjectStore: vi.fn().mockReturnValue({
-                createIndex: vi.fn(),
-              }),
+              createObjectStore,
             },
           },
         } as unknown as IDBVersionChangeEvent)
@@ -127,8 +128,45 @@ describe('IndexedDB Service', () => {
 
       const db = await openPromise
 
-      expect(mockIndexedDB.open).toHaveBeenCalledWith('habit-tracker', 1)
+      expect(mockIndexedDB.open).toHaveBeenCalledWith('habit-tracker', 2)
+      expect(createObjectStore).toHaveBeenCalledWith('habits', { keyPath: 'id' })
+      expect(createObjectStore).toHaveBeenCalledWith('settings', { keyPath: 'key' })
       expect(db).toBe(mockDB)
+    })
+
+    it('creates settings store on upgrade when habits already exist', async () => {
+      const mockOpenRequest = createMockRequest()
+      mockOpenRequest.result = mockDB
+      const createObjectStore = vi.fn().mockReturnValue({
+        createIndex: vi.fn(),
+      })
+
+      ;(mockIndexedDB.open as ReturnType<typeof vi.fn>).mockReturnValue(mockOpenRequest)
+
+      const openPromise = openDB()
+
+      await Promise.resolve()
+      const openRequest = mockOpenRequest as unknown as IDBOpenDBRequest
+      if (openRequest.onupgradeneeded) {
+        openRequest.onupgradeneeded({
+          target: {
+            result: {
+              objectStoreNames: {
+                contains: (name: string) => name === 'habits',
+              },
+              createObjectStore,
+            },
+          },
+        } as unknown as IDBVersionChangeEvent)
+      }
+      if (mockOpenRequest.onsuccess) {
+        mockOpenRequest.onsuccess({ target: { result: mockDB } })
+      }
+
+      await openPromise
+
+      expect(createObjectStore).toHaveBeenCalledWith('settings', { keyPath: 'key' })
+      expect(createObjectStore).not.toHaveBeenCalledWith('habits', { keyPath: 'id' })
     })
 
     it('handles database open errors', async () => {

--- a/src/services/indexedDB.ts
+++ b/src/services/indexedDB.ts
@@ -6,8 +6,9 @@ import { validateHabit } from '../utils/validation/validateHabit'
 import { validateId } from '../utils/validation/validateId'
 
 const DB_NAME = 'habit-tracker'
-const DB_VERSION = 1
+const DB_VERSION = 2
 const STORE_NAME = 'habits'
+const SETTINGS_STORE = 'settings'
 
 let dbInstance: IDBDatabase | null = null
 
@@ -99,6 +100,10 @@ export function openDB(): Promise<IDBDatabase> {
         objectStore.createIndex('name', 'name', { unique: false })
         objectStore.createIndex('createdDate', 'createdDate', { unique: false })
       }
+
+      if (!db.objectStoreNames.contains(SETTINGS_STORE)) {
+        db.createObjectStore(SETTINGS_STORE, { keyPath: 'key' })
+      }
     }
   })
 }
@@ -155,6 +160,79 @@ function getObjectStore(mode: IDBTransactionMode = 'readonly'): Promise<ObjectSt
         }
       })
   })
+}
+
+interface SettingsRow {
+  key: string
+  value: string
+}
+
+function getSettingsObjectStore(
+  mode: IDBTransactionMode = 'readonly'
+): Promise<ObjectStoreResult> {
+  return new Promise((resolve, reject) => {
+    openDB()
+      .then((db) => {
+        if (!db.objectStoreNames.contains(SETTINGS_STORE)) {
+          const indexedDBError = new IndexedDBError(
+            'INDEXEDDB_TRANSACTION_FAILED',
+            'Unable to access storage. Please refresh the page.',
+            `Object store "${SETTINGS_STORE}" does not exist`
+          )
+          logError(indexedDBError)
+          reject(indexedDBError)
+          return
+        }
+
+        const transaction = db.transaction([SETTINGS_STORE], mode)
+        const objectStore = transaction.objectStore(SETTINGS_STORE)
+
+        transaction.onerror = () => {
+          const error = transaction.error || new Error('Transaction failed')
+          const indexedDBError = new IndexedDBError(
+            'INDEXEDDB_TRANSACTION_FAILED',
+            'Unable to access storage. Please refresh the page.',
+            error instanceof Error ? error.message : String(error)
+          )
+          logError(indexedDBError)
+          reject(indexedDBError)
+        }
+
+        resolve({ objectStore, transaction })
+      })
+      .catch((error) => {
+        if (error instanceof IndexedDBError) {
+          reject(error)
+        } else {
+          const indexedDBError = new IndexedDBError(
+            'INDEXEDDB_TRANSACTION_FAILED',
+            'Unable to access storage. Please refresh the page.',
+            error instanceof Error ? error.message : String(error)
+          )
+          logError(indexedDBError)
+          reject(indexedDBError)
+        }
+      })
+  })
+}
+
+export async function getSetting(key: string): Promise<string | undefined> {
+  const { objectStore } = await getSettingsObjectStore('readonly')
+  const request = objectStore.get(key)
+  const row = await handleRequestError<SettingsRow | undefined>(
+    request,
+    'Failed to read setting'
+  )
+  if (row && typeof row === 'object' && 'value' in row) {
+    return String(row.value)
+  }
+  return undefined
+}
+
+export async function setSetting(key: string, value: string): Promise<void> {
+  const { objectStore } = await getSettingsObjectStore('readwrite')
+  const request = objectStore.put({ key, value } as SettingsRow)
+  await handleRequestError(request, 'Failed to write setting')
 }
 
 export async function addHabit(habit: Habit): Promise<string> {

--- a/src/services/languageStorage.test.ts
+++ b/src/services/languageStorage.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSetting, setSetting } = vi.hoisted(() => ({
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+}))
+
+vi.mock('./indexedDB', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./indexedDB')>()
+  return {
+    ...actual,
+    getSetting,
+    setSetting,
+  }
+})
+
+vi.unmock('./languageStorage')
+
+import { getPreferredLanguage, setPreferredLanguage } from './languageStorage'
+
+describe('languageStorage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns undefined when no preference is stored', async () => {
+    getSetting.mockResolvedValue(undefined)
+    await expect(getPreferredLanguage()).resolves.toBeUndefined()
+    expect(getSetting).toHaveBeenCalledWith('preferredLanguage')
+  })
+
+  it('returns locale when stored value is supported', async () => {
+    getSetting.mockResolvedValue('pt-BR')
+    await expect(getPreferredLanguage()).resolves.toBe('pt-BR')
+  })
+
+  it('returns undefined when stored value is not supported', async () => {
+    getSetting.mockResolvedValue('fr')
+    await expect(getPreferredLanguage()).resolves.toBeUndefined()
+  })
+
+  it('persists supported locale via setPreferredLanguage', async () => {
+    setSetting.mockResolvedValue(undefined)
+    await setPreferredLanguage('en')
+    expect(setSetting).toHaveBeenCalledWith('preferredLanguage', 'en')
+  })
+
+  it('does not persist unsupported locale', async () => {
+    // @ts-expect-error deliberate invalid code for runtime guard
+    await setPreferredLanguage('fr')
+    expect(setSetting).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/languageStorage.ts
+++ b/src/services/languageStorage.ts
@@ -1,0 +1,16 @@
+import { isSupportedLocale } from '../config/supportedLanguages'
+import type { LocaleCode } from '../locale/types'
+import { getSetting, setSetting } from './indexedDB'
+
+const PREFERRED_LANGUAGE_KEY = 'preferredLanguage'
+
+export async function getPreferredLanguage(): Promise<LocaleCode | undefined> {
+  const raw = await getSetting(PREFERRED_LANGUAGE_KEY)
+  if (raw === undefined) return undefined
+  return isSupportedLocale(raw) ? raw : undefined
+}
+
+export async function setPreferredLanguage(locale: LocaleCode): Promise<void> {
+  if (!isSupportedLocale(locale)) return
+  await setSetting(PREFERRED_LANGUAGE_KEY, locale)
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,2 +1,8 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+vi.mock('../services/languageStorage', () => ({
+  getPreferredLanguage: vi.fn(() => Promise.resolve('en')),
+  setPreferredLanguage: vi.fn(() => Promise.resolve()),
+}))
 

--- a/src/test/utils/render-helpers.tsx
+++ b/src/test/utils/render-helpers.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, ReactNode, Component, ErrorInfo } from 'react'
 import { render, RenderOptions } from '@testing-library/react'
 import { HabitProvider } from '../../contexts/HabitContext'
+import { LanguageProvider } from '../../contexts/LanguageContext'
 
 type CustomRenderOptions = Omit<RenderOptions, 'wrapper'>
 
@@ -9,7 +10,11 @@ export function renderWithProviders(
   options?: CustomRenderOptions
 ) {
   function Wrapper({ children }: { children: ReactNode }) {
-    return <HabitProvider>{children}</HabitProvider>
+    return (
+      <LanguageProvider initialLocale="en">
+        <HabitProvider>{children}</HabitProvider>
+      </LanguageProvider>
+    )
   }
 
   return render(ui, { wrapper: Wrapper, ...options })
@@ -56,4 +61,3 @@ export function renderWithErrorBoundary(
     </ErrorBoundary>
   )
 }
-

--- a/src/test/utils/renderWithLangReady.tsx
+++ b/src/test/utils/renderWithLangReady.tsx
@@ -1,0 +1,14 @@
+import type { ReactElement } from 'react'
+import { render, type RenderOptions } from '@testing-library/react'
+import { LanguageProvider } from '../../contexts/LanguageContext'
+
+/** Renders UI with synchronous English locale (matches test `LanguageProvider initialLocale`). */
+export function renderWithLangReady(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) {
+  return render(
+    <LanguageProvider initialLocale="en">{ui}</LanguageProvider>,
+    options
+  )
+}


### PR DESCRIPTION
Closes #83

GitHub issue: https://github.com/CalixtoTheBugHunter/habit-tracker/issues/83

## Description

- Users can choose a preferred language from Settings, with labels shown in each language’s native form.
- On first visit, the app picks a sensible default from the device language when it is supported, otherwise English.
- The choice is remembered across sessions so the UI stays in the selected language.
- Changing language updates the interface right away without losing context.


Made with [Cursor](https://cursor.com)