### PR TITLE
fix(pwa): improve ServiceWorkerUpdatePrompt contrast

### DIFF
--- a/src/components/pwa/ServiceWorkerUpdatePrompt/ServiceWorkerUpdatePrompt.css
+++ b/src/components/pwa/ServiceWorkerUpdatePrompt/ServiceWorkerUpdatePrompt.css
@@ -4,7 +4,7 @@
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
   background-color: var(--color-warning-bg);
-  color: var(--color-text-primary);
+  color: var(--color-on-warning);
   border: 1px solid var(--color-warning-border);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
@@ -37,20 +37,25 @@
 
 .sw-update-prompt__reload {
   padding: var(--spacing-xs) var(--spacing-sm);
-  background-color: var(--color-primary);
-  color: var(--color-button-primary-text);
-  border: none;
+  background-color: var(--color-surface);
+  color: var(--color-primary);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: var(--font-size-xs);
   font-weight: bold;
   font-family: var(--font-family);
-  transition: background-color var(--transition-base);
+  transition:
+    background-color var(--transition-base),
+    color var(--transition-base),
+    border-color var(--transition-base);
   white-space: nowrap;
 }
 
 .sw-update-prompt__reload:hover {
-  background-color: var(--color-primary-hover);
+  background-color: var(--color-surface-hover);
+  color: var(--color-primary-hover);
+  border-color: var(--color-border-hover);
 }
 
 .sw-update-prompt__reload:focus-visible {
@@ -61,8 +66,8 @@
 .sw-update-prompt__dismiss {
   padding: var(--spacing-xs) var(--spacing-sm);
   background-color: transparent;
-  color: var(--color-text-secondary);
-  border: 1px solid var(--color-border);
+  color: var(--color-on-warning-muted);
+  border: 1px solid var(--color-on-warning-outline);
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: var(--font-size-xs);
@@ -72,8 +77,8 @@
 }
 
 .sw-update-prompt__dismiss:hover {
-  background-color: var(--color-surface-hover);
-  color: var(--color-text-primary);
+  background-color: var(--color-on-warning-dismiss-hover-bg);
+  color: var(--color-on-warning);
 }
 
 .sw-update-prompt__dismiss:focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,11 @@
   --color-error-border: #ffcdd2;
   --color-warning: #e65100;
   --color-warning-bg: #fff3e0;
+  --color-warning-border: #ffcc80;
+  --color-on-warning: #bf360c;
+  --color-on-warning-muted: #4e342e;
+  --color-on-warning-outline: rgba(0, 0, 0, 0.28);
+  --color-on-warning-dismiss-hover-bg: rgba(0, 0, 0, 0.06);
   
   /* Interactive Elements */
   --color-button-primary-text: #000000;
@@ -103,6 +108,11 @@
     --color-error-border: #c62828;
     --color-warning: #ff9800;
     --color-warning-bg: #e65100;
+    --color-warning-border: #ff9800;
+    --color-on-warning: #ffffff;
+    --color-on-warning-muted: #f5f5f5;
+    --color-on-warning-outline: rgba(255, 255, 255, 0.72);
+    --color-on-warning-dismiss-hover-bg: rgba(255, 255, 255, 0.14);
     
     /* Interactive Elements */
     --color-button-primary-text: #000000;


### PR DESCRIPTION
## Description

- Update available banner is easier to read in light and dark mode, including the dismiss action and reload control.
- Reload uses a calmer surface-style button so it does not compete with the warning background.
- Dismiss label and outline stay legible on the orange warning strip.

Related: #61

Made with [Cursor](https://cursor.com)