### PR TITLE
feat(habits): add weekday goal scheduling with progress tracking

### DIFF
--- a/src/components/Statistics/HabitStatisticsCard.css
+++ b/src/components/Statistics/HabitStatisticsCard.css
@@ -45,6 +45,13 @@
   color: var(--color-text-primary);
 }
 
+.habit-stats-card__goal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-lg);
+}
+
 .habit-stats-card__progress-bar {
   width: 100%;
   height: 8px;

--- a/src/components/Statistics/HabitStatisticsCard.tsx
+++ b/src/components/Statistics/HabitStatisticsCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useLanguage } from '../../contexts/LanguageContext'
+import { formatMessage } from '../../locale'
 import { calculateStreak } from '../../utils/habit/calculateStreak'
 import {
   calculateLongestStreak,
@@ -7,6 +8,7 @@ import {
   calculateTotalDaysTracked,
   calculateWeeklyCompletionRate,
   calculateMonthlyCompletionRate,
+  calculateGoalProgress,
 } from '../../utils/habit/statisticsCalculations'
 import { AnnualCalendar } from '../habit/AnnualCalendar/AnnualCalendar'
 import type { Habit } from '../../types/habit'
@@ -26,7 +28,10 @@ export function HabitStatisticsCard({ habit }: HabitStatisticsCardProps) {
     weeklyRate: calculateWeeklyCompletionRate(habit.completionDates),
     monthlyRate: calculateMonthlyCompletionRate(habit.completionDates),
     totalDaysTracked: calculateTotalDaysTracked(habit.createdDate),
-  }), [habit.completionDates, habit.createdDate])
+    goalProgress: habit.goalDays !== undefined && habit.goalDays.length > 0
+      ? calculateGoalProgress(habit.completionDates, habit.goalDays)
+      : null,
+  }), [habit.completionDates, habit.createdDate, habit.goalDays])
 
   return (
     <article className="habit-stats-card">
@@ -80,6 +85,21 @@ export function HabitStatisticsCard({ habit }: HabitStatisticsCardProps) {
           </div>
         </div>
       </div>
+
+      {stats.goalProgress !== null && (
+        <div className="habit-stats-card__goal">
+          <span className="habit-stats-card__stat-label">{messages.statistics.goalProgress}</span>
+          <span className="habit-stats-card__stat-value">
+            {formatMessage(messages.statistics.goalProgressValue, {
+              completed: stats.goalProgress.completed,
+              target: stats.goalProgress.target,
+            })}
+          </span>
+          <div className="habit-stats-card__progress-bar" role="progressbar" aria-valuenow={stats.goalProgress.percentage} aria-valuemin={0} aria-valuemax={100} aria-label={messages.statistics.goalProgress}>
+            <div className="habit-stats-card__progress-fill" style={{ width: `${stats.goalProgress.percentage}%` }} />
+          </div>
+        </div>
+      )}
 
       <AnnualCalendar habit={habit} />
     </article>

--- a/src/components/habit/GoalBadge/GoalBadge.css
+++ b/src/components/habit/GoalBadge/GoalBadge.css
@@ -1,0 +1,17 @@
+.goal-badge {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  background-color: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid var(--color-success-border);
+}
+
+@media (max-width: 600px) {
+  .goal-badge {
+    font-size: var(--font-size-xs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+}

--- a/src/components/habit/GoalBadge/GoalBadge.test.tsx
+++ b/src/components/habit/GoalBadge/GoalBadge.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { GoalBadge } from './GoalBadge'
+import { renderWithProviders } from '../../../test/utils/render-helpers'
+import { openDB } from '../../../services/indexedDB'
+
+vi.mock('../../../services/indexedDB', () => ({
+  openDB: vi.fn(),
+  getAllHabits: vi.fn(),
+  updateHabit: vi.fn(),
+  deleteHabit: vi.fn(),
+  testUtils: {
+    resetDB: vi.fn(),
+  },
+}))
+
+vi.mock('../../../services/migration', () => ({
+  runMigrations: vi.fn(),
+  migrations: [],
+}))
+
+describe('GoalBadge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+    vi.useFakeTimers()
+    // 2025-01-15 = Wednesday; ISO week Mon 2025-01-13 – Sun 2025-01-19
+    // Mon/Wed/Fri = [1,3,5] → 2025-01-13, 2025-01-15, 2025-01-17
+    vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when no goal days are completed', () => {
+    const { container } = renderWithProviders(
+      <GoalBadge goalDays={[1, 3, 5]} completionDates={[]} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when only some goal days are completed', () => {
+    const { container } = renderWithProviders(
+      <GoalBadge
+        goalDays={[1, 3, 5]}
+        completionDates={['2025-01-13T00:00:00.000Z', '2025-01-15T00:00:00.000Z']}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders badge when all goal days in the current week are completed', () => {
+    const dates = [
+      '2025-01-13T00:00:00.000Z', // Mon
+      '2025-01-15T00:00:00.000Z', // Wed
+      '2025-01-17T00:00:00.000Z', // Fri
+    ]
+    renderWithProviders(<GoalBadge goalDays={[1, 3, 5]} completionDates={dates} />)
+    expect(screen.getByText('Goal met!')).toBeInTheDocument()
+  })
+
+  it('renders badge for a single-day goal when that day is completed', () => {
+    renderWithProviders(
+      <GoalBadge goalDays={[3]} completionDates={['2025-01-15T00:00:00.000Z']} />
+    )
+    expect(screen.getByText('Goal met!')).toBeInTheDocument()
+  })
+
+  it('badge has correct aria-label', () => {
+    const dates = [
+      '2025-01-13T00:00:00.000Z',
+      '2025-01-15T00:00:00.000Z',
+      '2025-01-17T00:00:00.000Z',
+    ]
+    renderWithProviders(<GoalBadge goalDays={[1, 3, 5]} completionDates={dates} />)
+    expect(screen.getByLabelText(/goal met: 3 of 3 days this week/i)).toBeInTheDocument()
+  })
+
+  it('does not count completions from previous week toward goal', () => {
+    const dates = [
+      '2025-01-06T00:00:00.000Z', // Mon of previous week
+      '2025-01-08T00:00:00.000Z', // Wed of previous week
+      '2025-01-10T00:00:00.000Z', // Fri of previous week
+    ]
+    const { container } = renderWithProviders(
+      <GoalBadge goalDays={[1, 3, 5]} completionDates={dates} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/components/habit/GoalBadge/GoalBadge.test.tsx
+++ b/src/components/habit/GoalBadge/GoalBadge.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen } from '@testing-library/react'
 import { GoalBadge } from './GoalBadge'
 import { renderWithProviders } from '../../../test/utils/render-helpers'
-import { openDB } from '../../../services/indexedDB'
 
 vi.mock('../../../services/indexedDB', () => ({
   openDB: vi.fn(),
@@ -21,8 +20,6 @@ vi.mock('../../../services/migration', () => ({
 
 describe('GoalBadge', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
     vi.useFakeTimers()
     // 2025-01-15 = Wednesday; ISO week Mon 2025-01-13 – Sun 2025-01-19
     // Mon/Wed/Fri = [1,3,5] → 2025-01-13, 2025-01-15, 2025-01-17

--- a/src/components/habit/GoalBadge/GoalBadge.tsx
+++ b/src/components/habit/GoalBadge/GoalBadge.tsx
@@ -1,0 +1,29 @@
+import { useLanguage } from '../../../contexts/LanguageContext'
+import { formatMessage } from '../../../locale'
+import { calculateGoalProgress } from '../../../utils/habit/statisticsCalculations'
+import './GoalBadge.css'
+
+interface GoalBadgeProps {
+  goalDays: number[]
+  completionDates: string[]
+}
+
+export function GoalBadge({ goalDays, completionDates }: GoalBadgeProps) {
+  const { messages } = useLanguage()
+  const progress = calculateGoalProgress(completionDates, goalDays)
+
+  if (progress.percentage < 100) {
+    return null
+  }
+
+  const ariaLabel = formatMessage(messages.goalBadge.goalMetAriaLabel, {
+    completed: progress.completed,
+    target: progress.target,
+  })
+
+  return (
+    <span className="goal-badge" aria-label={ariaLabel}>
+      {messages.statistics.goalMet}
+    </span>
+  )
+}

--- a/src/components/habit/HabitForm/HabitForm.css
+++ b/src/components/habit/HabitForm/HabitForm.css
@@ -117,6 +117,11 @@
   color: var(--color-primary);
 }
 
+.habit-form-goaldays__day:focus-within {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
 .habit-form-goaldays__day--checked {
   border-color: var(--color-primary);
   background-color: var(--color-primary-light);

--- a/src/components/habit/HabitForm/HabitForm.css
+++ b/src/components/habit/HabitForm/HabitForm.css
@@ -76,6 +76,61 @@
   overflow-x: hidden;
 }
 
+.habit-form-hint {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.habit-form-goaldays {
+  border: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-lg);
+}
+
+.habit-form-goaldays__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+}
+
+.habit-form-goaldays__day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background-color: var(--color-surface);
+  transition: border-color var(--transition-base), background-color var(--transition-base), color var(--transition-base);
+  user-select: none;
+}
+
+.habit-form-goaldays__day:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.habit-form-goaldays__day--checked {
+  border-color: var(--color-primary);
+  background-color: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+.habit-form-goaldays__checkbox {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
 .habit-form-error {
   display: block;
   margin-top: var(--spacing-sm);

--- a/src/components/habit/HabitForm/HabitForm.tsx
+++ b/src/components/habit/HabitForm/HabitForm.tsx
@@ -23,6 +23,7 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
   const [description, setDescription] = useState(habit?.description || '')
   const [stackingHabitIds, setStackingHabitIds] = useState<string[]>(habit?.stackingHabits ?? [])
   const [stackingStepLabels, setStackingStepLabels] = useState<Record<string, string>>(habit?.stackingStepLabels ?? {})
+  const [goalDays, setGoalDays] = useState<number[]>(habit?.goalDays ?? [])
   const [nameError, setNameError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -38,12 +39,14 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
       setDescription(habit.description || '')
       setStackingHabitIds(habit.stackingHabits ?? [])
       setStackingStepLabels(habit.stackingStepLabels ?? {})
+      setGoalDays(habit.goalDays ?? [])
       setShowDescription(true)
     } else {
       setName('')
       setDescription('')
       setStackingHabitIds([])
       setStackingStepLabels({})
+      setGoalDays([])
       setShowDescription(false)
     }
   }, [habit])
@@ -105,6 +108,7 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
         stackingCompletions: hasStacking && Object.keys(stackingCompletions ?? {}).length > 0 ? stackingCompletions : undefined,
         stackingStepLabels: labelsForStack && Object.keys(labelsForStack).length > 0 ? labelsForStack : undefined,
         autoCompletedDates: hasStacking ? habit?.autoCompletedDates : undefined,
+        goalDays: goalDays.length > 0 ? goalDays : undefined,
       }
 
       if (isEditMode) {
@@ -152,6 +156,7 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
       setDescription('')
       setStackingHabitIds([])
       setStackingStepLabels({})
+      setGoalDays([])
       setShowDescription(false)
     }
     setNameError(null)
@@ -229,6 +234,31 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
             excludeId={habit?.id}
             disabled={isSubmitting}
           />
+          <fieldset className="habit-form-field habit-form-goaldays" disabled={isSubmitting}>
+            <legend className="habit-form-label">{messages.habitForm.labels.goalDays}</legend>
+            <div className="habit-form-goaldays__grid">
+              {([1, 2, 3, 4, 5, 6, 0] as const).map((jsDay) => {
+                const labelKey = (['weekdaySun', 'weekdayMon', 'weekdayTue', 'weekdayWed', 'weekdayThu', 'weekdayFri', 'weekdaySat'] as const)[jsDay]
+                const label = messages.habitForm.labels[labelKey]
+                const checked = goalDays.includes(jsDay)
+                return (
+                  <label key={jsDay} className={`habit-form-goaldays__day${checked ? ' habit-form-goaldays__day--checked' : ''}`}>
+                    <input
+                      type="checkbox"
+                      className="habit-form-goaldays__checkbox"
+                      checked={checked}
+                      onChange={() => {
+                        setGoalDays(prev =>
+                          prev.includes(jsDay) ? prev.filter(d => d !== jsDay) : [...prev, jsDay]
+                        )
+                      }}
+                    />
+                    {label}
+                  </label>
+                )
+              })}
+            </div>
+          </fieldset>
         </>
       )}
 

--- a/src/components/habit/HabitForm/HabitForm.tsx
+++ b/src/components/habit/HabitForm/HabitForm.tsx
@@ -151,6 +151,7 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
       setDescription(habit.description || '')
       setStackingHabitIds(habit.stackingHabits ?? [])
       setStackingStepLabels(habit.stackingStepLabels ?? {})
+      setGoalDays(habit.goalDays ?? [])
     } else {
       setName('')
       setDescription('')

--- a/src/components/habit/HabitList/HabitList.tsx
+++ b/src/components/habit/HabitList/HabitList.tsx
@@ -8,6 +8,7 @@ import { getHabitsToPersistAfterStackingToggle } from '../../../utils/habit/stac
 import { HabitStackingAccordion } from '../HabitStackingAccordion/HabitStackingAccordion'
 import { ConfirmationModal } from '../../modal/ConfirmationModal/ConfirmationModal'
 import { StreakBadge } from '../StreakBadge/StreakBadge'
+import { GoalBadge } from '../GoalBadge/GoalBadge'
 import type { Habit } from '../../../types/habit'
 import './HabitList.css'
 
@@ -121,6 +122,9 @@ export function HabitList({ onEdit }: HabitListProps) {
             <div className="habit-header">
               <h3 className="habit-name">{habit.name || messages.habitList.unnamedHabit}</h3>
               <StreakBadge streak={habit.streak} />
+              {habit.goalDays !== undefined && habit.goalDays.length > 0 && (
+                <GoalBadge goalDays={habit.goalDays} completionDates={habit.completionDates} />
+              )}
             </div>
             {habit.description && (
               <p className="habit-description">{habit.description}</p>

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -18,6 +18,14 @@ export const en = {
       name: 'Name',
       description: 'Description',
       required: '*',
+      goalDays: 'Goal days (optional)',
+      weekdaySun: 'Sun',
+      weekdayMon: 'Mon',
+      weekdayTue: 'Tue',
+      weekdayWed: 'Wed',
+      weekdayThu: 'Thu',
+      weekdayFri: 'Fri',
+      weekdaySat: 'Sat',
     },
     buttons: {
       create: 'Create Habit',
@@ -49,6 +57,9 @@ export const en = {
       addButton: 'Add',
       removeAria: 'Remove {name} from stack',
     },
+  },
+  goalBadge: {
+    goalMetAriaLabel: 'Goal met: {completed} of {target} days this week',
   },
   habitList: {
     loading: 'Loading habits...',
@@ -151,6 +162,9 @@ export const en = {
     monthlyRate: 'Last 30 days',
     totalDaysTracked: 'Days tracked',
     daysUnit: 'days',
+    goalProgress: 'Goal progress',
+    goalProgressValue: '{completed}/{target} this week',
+    goalMet: 'Goal met!',
   },
   settings: {
     title: 'Settings',

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -18,6 +18,14 @@ export const ptBR = {
       name: 'Nome',
       description: 'Descrição',
       required: '*',
+      goalDays: 'Dias da meta (opcional)',
+      weekdaySun: 'Dom',
+      weekdayMon: 'Seg',
+      weekdayTue: 'Ter',
+      weekdayWed: 'Qua',
+      weekdayThu: 'Qui',
+      weekdayFri: 'Sex',
+      weekdaySat: 'Sáb',
     },
     buttons: {
       create: 'Criar Hábito',
@@ -49,6 +57,9 @@ export const ptBR = {
       addButton: 'Adicionar',
       removeAria: 'Remover {name} da cadeia de hábitos',
     },
+  },
+  goalBadge: {
+    goalMetAriaLabel: 'Meta atingida: {completed} de {target} dias esta semana',
   },
   habitList: {
     loading: 'Carregando hábitos...',
@@ -152,6 +163,9 @@ export const ptBR = {
     monthlyRate: 'Últimos 30 dias',
     totalDaysTracked: 'Dias rastreados',
     daysUnit: 'dias',
+    goalProgress: 'Progresso da meta',
+    goalProgressValue: '{completed}/{target} esta semana',
+    goalMet: 'Meta atingida!',
   },
   settings: {
     title: 'Configurações',

--- a/src/services/indexedDB.ts
+++ b/src/services/indexedDB.ts
@@ -263,7 +263,11 @@ export async function getAllHabits(): Promise<Habit[]> {
   const { objectStore } = await getObjectStore('readonly')
   const request = objectStore.getAll()
   const result = await handleRequestError(request, 'Failed to get all habits')
-  return result || []
+  const habits = result || []
+  for (const habit of habits) {
+    validateHabit(habit)
+  }
+  return habits
 }
 
 export async function updateHabit(habit: Habit): Promise<string> {

--- a/src/test/fixtures/habits.ts
+++ b/src/test/fixtures/habits.ts
@@ -37,9 +37,15 @@ export const mockHabits = {
 
   /**
    * Creates a habit with completion dates.
-   * 
+   *
    * @param dates - Array of ISO 8601 date strings
    */
   withCompletions: (dates: string[]): Habit => createMockHabit({ completionDates: dates }),
+
+  /**
+   * Creates a habit with a goal set.
+   */
+  withGoal: (goalDays: number[], completionDates: string[] = []): Habit =>
+    createMockHabit({ goalDays, completionDates }),
 }
 

--- a/src/types/habit.ts
+++ b/src/types/habit.ts
@@ -27,5 +27,6 @@ export interface Habit {
   stackingCompletions?: Record<string, string[]>
   stackingStepLabels?: Record<string, string>
   autoCompletedDates?: string[]
+  goalDays?: number[]
 }
 

--- a/src/utils/habit/statisticsCalculations.test.ts
+++ b/src/utils/habit/statisticsCalculations.test.ts
@@ -5,7 +5,9 @@ import {
   calculateTotalDaysTracked,
   calculateWeeklyCompletionRate,
   calculateMonthlyCompletionRate,
+  calculateGoalProgress,
 } from './statisticsCalculations'
+
 
 describe('statisticsCalculations', () => {
   beforeEach(() => {
@@ -217,6 +219,59 @@ describe('statisticsCalculations', () => {
         dates.push(date.toISOString())
       }
       expect(calculateMonthlyCompletionRate(dates)).toBe(33) // 10/30 = 33.33 rounded
+    })
+  })
+
+  describe('calculateGoalProgress', () => {
+    // Fake time: 2025-01-15 (Wednesday). ISO week: Mon 2025-01-13 – Sun 2025-01-19.
+    // goalDays uses JS weekday numbers: 0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat
+    // Mon/Wed/Fri = [1, 3, 5] → dates 2025-01-13, 2025-01-15, 2025-01-17
+
+    it('should return 0 completed and 0% for empty dates', () => {
+      expect(calculateGoalProgress([], [1, 3, 5])).toEqual({ completed: 0, target: 3, percentage: 0 })
+    })
+
+    it('should count completions on goal days within the current ISO week', () => {
+      const dates = [
+        '2025-01-13T00:00:00.000Z', // Monday (1) — goal day ✓
+        '2025-01-15T00:00:00.000Z', // Wednesday (3) — goal day ✓
+        '2025-01-12T00:00:00.000Z', // Sunday previous week — NOT in current week
+      ]
+      // Fri (2025-01-17) not yet completed
+      expect(calculateGoalProgress(dates, [1, 3, 5])).toEqual({ completed: 2, target: 3, percentage: 67 })
+    })
+
+    it('should return 100% when all goal days are completed', () => {
+      const dates = [
+        '2025-01-13T00:00:00.000Z', // Mon
+        '2025-01-15T00:00:00.000Z', // Wed
+        '2025-01-17T00:00:00.000Z', // Fri
+      ]
+      expect(calculateGoalProgress(dates, [1, 3, 5])).toEqual({ completed: 3, target: 3, percentage: 100 })
+    })
+
+    it('should ignore completions from the previous week', () => {
+      const dates = [
+        '2025-01-06T00:00:00.000Z', // Mon of previous week
+        '2025-01-08T00:00:00.000Z', // Wed of previous week
+        '2025-01-10T00:00:00.000Z', // Fri of previous week
+      ]
+      expect(calculateGoalProgress(dates, [1, 3, 5])).toEqual({ completed: 0, target: 3, percentage: 0 })
+    })
+
+    it('should correctly map Sunday (0) to 2025-01-19 in the current ISO week', () => {
+      const dates = [
+        '2025-01-19T00:00:00.000Z', // Sunday of current ISO week
+      ]
+      expect(calculateGoalProgress(dates, [0])).toEqual({ completed: 1, target: 1, percentage: 100 })
+    })
+
+    it('should not count completions on non-goal days', () => {
+      const dates = [
+        '2025-01-14T00:00:00.000Z', // Tuesday — not a goal day for [1,3,5]
+        '2025-01-16T00:00:00.000Z', // Thursday — not a goal day for [1,3,5]
+      ]
+      expect(calculateGoalProgress(dates, [1, 3, 5])).toEqual({ completed: 0, target: 3, percentage: 0 })
     })
   })
 })

--- a/src/utils/habit/statisticsCalculations.ts
+++ b/src/utils/habit/statisticsCalculations.ts
@@ -93,3 +93,37 @@ export function calculateMonthlyCompletionRate(completionDates: string[]): numbe
   const count = last30Days.filter(d => uniqueDates.includes(d)).length
   return Math.round((count / 30) * 100)
 }
+
+export function calculateGoalProgress(
+  completionDates: string[],
+  goalDays: number[]
+): { completed: number; target: number; percentage: number } {
+  const today = getTodayLocalDateString()
+  const parts = today.split('-')
+  const year = Number(parts[0])
+  const month = Number(parts[1])
+  const day = Number(parts[2])
+
+  // Find Monday of the current ISO week
+  const todayDate = new Date(Date.UTC(year, month - 1, day))
+  const dayOfWeek = todayDate.getUTCDay() // 0=Sun, 1=Mon, ...6=Sat
+  const daysFromMonday = (dayOfWeek + 6) % 7
+
+  // Build a map from JS weekday number (0=Sun…6=Sat) to its date string in this ISO week
+  const weekDayToDate: Record<number, string> = {}
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(Date.UTC(year, month - 1, day - daysFromMonday + i))
+    const y = d.getUTCFullYear()
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+    const dd = String(d.getUTCDate()).padStart(2, '0')
+    weekDayToDate[d.getUTCDay()] = `${y}-${m}-${dd}`
+  }
+
+  const goalDates = goalDays.map(jsDay => weekDayToDate[jsDay]!).filter(Boolean)
+  const uniqueDates = getUniqueSortedDates(completionDates)
+  const completed = goalDates.filter(d => uniqueDates.includes(d)).length
+  const target = goalDays.length
+  const percentage = Math.min(Math.round((completed / target) * 100), 100)
+
+  return { completed, target, percentage }
+}

--- a/src/utils/validation/validateHabit.test.ts
+++ b/src/utils/validation/validateHabit.test.ts
@@ -271,6 +271,97 @@ describe('validateHabit', () => {
       }
       expect(() => validateHabit(invalid)).toThrow('All autoCompletedDates must be valid ISO 8601 date strings')
     })
+
+    it('should reject goalDays that is not an array', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: 1,
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit goalDays must be an array if provided')
+    })
+
+    it('should reject goalDays with zero elements', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [],
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit goalDays must have between 1 and 7 elements')
+    })
+
+    it('should reject goalDays with more than 7 elements', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [0, 1, 2, 3, 4, 5, 6, 0],
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit goalDays must have between 1 and 7 elements')
+    })
+
+    it('should reject goalDays with an out-of-range value', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [7],
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit goalDays elements must be integers between 0 and 6')
+    })
+
+    it('should reject goalDays with a non-integer value', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [1.5],
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit goalDays elements must be integers between 0 and 6')
+    })
+
+    it('should reject goalDays with duplicate values', () => {
+      const invalid = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [1, 3, 1],
+      }
+      expect(() => validateHabit(invalid)).toThrow('Habit goalDays must not contain duplicate values')
+    })
+  })
+
+  describe('valid goalDays', () => {
+    it('should accept a single goal day', () => {
+      const habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [3],
+      }
+      expect(() => validateHabit(habit)).not.toThrow()
+    })
+
+    it('should accept all seven days', () => {
+      const habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        goalDays: [0, 1, 2, 3, 4, 5, 6],
+      }
+      expect(() => validateHabit(habit)).not.toThrow()
+    })
+
+    it('should accept undefined goalDays', () => {
+      const habit: Habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+      }
+      expect(() => validateHabit(habit)).not.toThrow()
+    })
   })
 })
 

--- a/src/utils/validation/validateHabit.ts
+++ b/src/utils/validation/validateHabit.ts
@@ -113,6 +113,23 @@ export function validateHabit(habit: unknown): asserts habit is Habit {
     }
   }
 
+  if (habitObj.goalDays !== undefined) {
+    if (!Array.isArray(habitObj.goalDays)) {
+      throw new Error('Habit goalDays must be an array if provided')
+    }
+    if (habitObj.goalDays.length < 1 || habitObj.goalDays.length > 7) {
+      throw new Error('Habit goalDays must have between 1 and 7 elements')
+    }
+    for (const day of habitObj.goalDays) {
+      if (typeof day !== 'number' || !Number.isInteger(day) || day < 0 || day > 6) {
+        throw new Error('Habit goalDays elements must be integers between 0 and 6')
+      }
+    }
+    if (new Set(habitObj.goalDays).size !== habitObj.goalDays.length) {
+      throw new Error('Habit goalDays must not contain duplicate values')
+    }
+  }
+
   const stringFields = ['name', 'description']
   for (const field of stringFields) {
     if (habitObj[field] !== undefined && typeof habitObj[field] !== 'string') {


### PR DESCRIPTION
Closes #20

## Description
* Users can select specific weekdays (Mon–Sun) as goal days when creating or editing a habit
* Progress is tracked weekly — the Statistics page shows a progress bar with "X/N this week"
* A "Goal met!" badge appears inline on the habit list when all scheduled days for the current ISO week are completed
* Goal is optional and fully backward-compatible — existing habits without goal days are unaffected

## Screenshots