### PR TITLE
Visual fixes: theming, responsive layout, and app header polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,22 @@
     <link href="https://fonts.googleapis.com/css2?family=Sansita+Swashed:wght@400;600;700&display=swap" rel="stylesheet" media="all">
   </head>
   <body>
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('preferredTheme')
+          var resolved
+          if (t === 'light' || t === 'dark') {
+            resolved = t
+          } else {
+            resolved = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light'
+          }
+          document.documentElement.setAttribute('data-theme', resolved)
+        } catch (e) {}
+      })()
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.css
+++ b/src/App.css
@@ -34,10 +34,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
   padding: 0 var(--spacing-lg);
-  max-width: 1200px;
-  margin: 0 auto;
   flex: 1;
 }
 
@@ -45,4 +42,9 @@
   .app-main {
     padding: 0 var(--spacing-3xl);
   }
+}
+
+.habit-list-container {
+  width: 100%;
+  max-width: 100%;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,12 +30,22 @@ function AppContent() {
     setEditingHabit(undefined)
   }
 
+  const goHome = () => {
+    handleNavigate('home')
+    setMenuOpen(false)
+  }
+
   if (isLoading) {
     return (
       <div className="app">
         <OfflineIndicator />
         <ServiceWorkerUpdatePrompt />
-        <AppHeader onMenuToggle={() => setMenuOpen(prev => !prev)} menuOpen={menuOpen} />
+        <AppHeader
+          onMenuToggle={() => setMenuOpen(prev => !prev)}
+          menuOpen={menuOpen}
+          onHomeClick={goHome}
+          homeIsActive={activeView === 'home'}
+        />
         <SideMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} activeView={activeView} onNavigate={handleNavigate} />
         <div className="app-loading" role="status" aria-live="polite" aria-atomic="true">
           <p>{messages.app.loading}</p>
@@ -49,7 +59,12 @@ function AppContent() {
       <div className="app">
         <OfflineIndicator />
         <ServiceWorkerUpdatePrompt />
-        <AppHeader onMenuToggle={() => setMenuOpen(prev => !prev)} menuOpen={menuOpen} />
+        <AppHeader
+          onMenuToggle={() => setMenuOpen(prev => !prev)}
+          menuOpen={menuOpen}
+          onHomeClick={goHome}
+          homeIsActive={activeView === 'home'}
+        />
         <SideMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} activeView={activeView} onNavigate={handleNavigate} />
         <div className="app-error" role="alert" aria-live="assertive" aria-atomic="true">
           <p className="error">{formatMessage(messages.app.error, { error })}</p>
@@ -62,7 +77,12 @@ function AppContent() {
     <div className="app">
       <OfflineIndicator />
       <ServiceWorkerUpdatePrompt />
-      <AppHeader onMenuToggle={() => setMenuOpen(prev => !prev)} menuOpen={menuOpen} />
+      <AppHeader
+        onMenuToggle={() => setMenuOpen(prev => !prev)}
+        menuOpen={menuOpen}
+        onHomeClick={goHome}
+        homeIsActive={activeView === 'home'}
+      />
       <SideMenu isOpen={menuOpen} onClose={() => setMenuOpen(false)} activeView={activeView} onNavigate={handleNavigate} />
       <main className="app-main">
         {activeView === 'home' && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,9 @@ function AppContent() {
               onSuccess={() => setEditingHabit(undefined)}
               onCancel={() => setEditingHabit(undefined)}
             />
-            <HabitList onEdit={setEditingHabit} />
+            <section className="habit-list-container">
+              <HabitList onEdit={setEditingHabit} />
+            </section>
           </>
         )}
         {activeView === 'settings' && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import './App.css'
 import { formatMessage } from './locale'
 import { LanguageProvider, useLanguage } from './contexts/LanguageContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 import { HabitProvider, useHabits } from './contexts/HabitContext'
 import {
   HabitList,
@@ -87,13 +88,15 @@ function AppContent() {
 
 function App() {
   return (
-    <LanguageProvider>
-      <ErrorBoundary>
-        <HabitProvider>
-          <AppContent />
-        </HabitProvider>
-      </ErrorBoundary>
-    </LanguageProvider>
+    <ThemeProvider>
+      <LanguageProvider>
+        <ErrorBoundary>
+          <HabitProvider>
+            <AppContent />
+          </HabitProvider>
+        </ErrorBoundary>
+      </LanguageProvider>
+    </ThemeProvider>
   )
 }
 

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -14,6 +14,11 @@
   backdrop-filter: saturate(1.8) blur(24px);
 }
 
+/* Forced light theme: avoid dark frosted bar + heavy blur (only blur in the app; dark OS + app light is common). */
+:root[data-theme='light'] .app-header {
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
 .app-header__menu-button {
   display: flex;
   align-items: center;
@@ -69,6 +74,9 @@
   transform: translateY(15px);
 }
 
+:root[data-theme='light'] .app-header__logo img {
+  mix-blend-mode: difference;
+}
 
 @media (max-width: 600px) {
   .app-header {

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -6,13 +6,12 @@
   padding: var(--spacing-lg) var(--spacing-2xl);
   padding-top: calc(var(--spacing-lg) + env(safe-area-inset-top));
   border-bottom: 1px solid var(--color-border);
-  background-color: rgba(0,0,0,0.4);
+  background-color: rgba(0, 0, 0, 0.4);
   position: sticky;
   top: 0;
   z-index: var(--z-index-indicator);
-  backdrop-filter: saturate(10.5) blur(24px);
-  mix-blend-mode: difference;
-
+  -webkit-backdrop-filter: saturate(1.8) blur(24px);
+  backdrop-filter: saturate(1.8) blur(24px);
 }
 
 .app-header__menu-button {

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -44,13 +44,30 @@
 }
 
 .app-header__logo {
-  display: inline-block;
-  margin: 0 0 var(--spacing-lg) 0;
   padding: 0;
-  position: relative;
   font-size: inherit;
   font-weight: normal;
   line-height: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.app-header__logo-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--radius-md);
+  max-width: 100%;
+  transition: background-color var(--transition-fast);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin: calc(-1 * var(--spacing-xs)) calc(-1 * var(--spacing-sm));
+}
+
+.app-header__logo-link:hover {
+  background-color: var(--color-surface-hover);
 }
 
 .app-header__logo-text {
@@ -65,17 +82,21 @@
   border: 0;
 }
 
-.app-header__logo img {
+.app-header__logo-mark {
   display: block;
   width: 200px;
   height: 50px;
-  max-width: none;
-  object-fit: cover;
-  transform: translateY(15px);
-}
-
-:root[data-theme='light'] .app-header__logo img {
-  mix-blend-mode: difference;
+  max-width: 100%;
+  flex-shrink: 0;
+  background-color: var(--app-header-logo-fill, var(--color-text-primary));
+  -webkit-mask-image: url('/logo.png');
+  mask-image: url('/logo.png');
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
 }
 
 @media (max-width: 600px) {

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -14,7 +14,6 @@
   backdrop-filter: saturate(1.8) blur(24px);
 }
 
-/* Forced light theme: avoid dark frosted bar + heavy blur (only blur in the app; dark OS + app light is common). */
 :root[data-theme='light'] .app-header {
   background-color: rgba(255, 255, 255, 0.4);
 }

--- a/src/components/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppHeader/AppHeader.test.tsx
@@ -23,21 +23,53 @@ vi.mock('../pwa/InstallPrompt/InstallPrompt', () => ({
   InstallPrompt: () => <div data-testid="install-prompt" />,
 }))
 
+const defaultHomeProps = {
+  onHomeClick: vi.fn(),
+  homeIsActive: false,
+}
+
 describe('AppHeader', () => {
-  it('should render logo', () => {
-    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} />)
-    expect(screen.getByRole('heading', { name: /atomic habit tracker/i })).toBeInTheDocument()
+  it('should render logo as home link with app title as accessible name', () => {
+    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} {...defaultHomeProps} />)
+    const link = screen.getByRole('link', { name: /atomic habit tracker/i })
+    expect(link).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1 })).toContainElement(link)
+  })
+
+  it('should set aria-current=page on home link when home is active', () => {
+    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} onHomeClick={vi.fn()} homeIsActive />)
+    expect(screen.getByRole('link', { name: /atomic habit tracker/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
+  it('should not set aria-current on home link when home is not active', () => {
+    render(
+      <AppHeader onMenuToggle={vi.fn()} menuOpen={false} onHomeClick={vi.fn()} homeIsActive={false} />
+    )
+    expect(screen.getByRole('link', { name: /atomic habit tracker/i })).not.toHaveAttribute(
+      'aria-current'
+    )
+  })
+
+  it('should call onHomeClick when logo link is activated', async () => {
+    const user = userEvent.setup()
+    const onHomeClick = vi.fn()
+    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} onHomeClick={onHomeClick} homeIsActive={false} />)
+    await user.click(screen.getByRole('link', { name: /atomic habit tracker/i }))
+    expect(onHomeClick).toHaveBeenCalledTimes(1)
   })
 
   it('should render menu button with open aria when closed', () => {
-    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} />)
+    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} {...defaultHomeProps} />)
     const button = screen.getByRole('button', { name: /open menu/i })
     expect(button).toBeInTheDocument()
     expect(button).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('should render menu button with close aria when open', () => {
-    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={true} />)
+    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={true} {...defaultHomeProps} />)
     const button = screen.getByRole('button', { name: /close menu/i })
     expect(button).toBeInTheDocument()
     expect(button).toHaveAttribute('aria-expanded', 'true')
@@ -46,14 +78,14 @@ describe('AppHeader', () => {
   it('should call onMenuToggle when menu button is clicked', async () => {
     const user = userEvent.setup()
     const onMenuToggle = vi.fn()
-    render(<AppHeader onMenuToggle={onMenuToggle} menuOpen={false} />)
+    render(<AppHeader onMenuToggle={onMenuToggle} menuOpen={false} {...defaultHomeProps} />)
 
     await user.click(screen.getByRole('button', { name: /open menu/i }))
     expect(onMenuToggle).toHaveBeenCalledTimes(1)
   })
 
   it('should render install prompt', () => {
-    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} />)
+    render(<AppHeader onMenuToggle={vi.fn()} menuOpen={false} {...defaultHomeProps} />)
     expect(screen.getByTestId('install-prompt')).toBeInTheDocument()
   })
 })

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react'
 import { Menu, X } from 'lucide-react'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { InstallPrompt } from '../pwa/InstallPrompt/InstallPrompt'
@@ -6,10 +7,19 @@ import './AppHeader.css'
 interface AppHeaderProps {
   onMenuToggle: () => void
   menuOpen: boolean
+  onHomeClick: () => void
+  homeIsActive: boolean
 }
 
-export function AppHeader({ onMenuToggle, menuOpen }: AppHeaderProps) {
+export function AppHeader({ onMenuToggle, menuOpen, onHomeClick, homeIsActive }: AppHeaderProps) {
   const { messages } = useLanguage()
+  const homeHref = import.meta.env.BASE_URL
+
+  const handleLogoClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+    e.preventDefault()
+    onHomeClick()
+  }
 
   return (
     <header className="app-header">
@@ -27,14 +37,15 @@ export function AppHeader({ onMenuToggle, menuOpen }: AppHeaderProps) {
         )}
       </button>
       <h1 className="app-header__logo">
-        <img
-          src="/logo.png"
-          alt=""
-          width={214}
-          height={50}
-          decoding="async"
-        />
-        <span className="app-header__logo-text">{messages.app.title}</span>
+        <a
+          className="app-header__logo-link"
+          href={homeHref}
+          onClick={handleLogoClick}
+          aria-current={homeIsActive ? 'page' : undefined}
+        >
+          <span className="app-header__logo-mark" aria-hidden="true" />
+          <span className="app-header__logo-text">{messages.app.title}</span>
+        </a>
       </h1>
       <div className="app-header__actions">
         <InstallPrompt />

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -29,6 +29,7 @@ export function AppHeader({ onMenuToggle, menuOpen, onHomeClick, homeIsActive }:
         onClick={onMenuToggle}
         aria-label={menuOpen ? messages.appHeader.menuButtonCloseAria : messages.appHeader.menuButtonOpenAria}
         aria-expanded={menuOpen}
+        aria-controls="side-menu"
       >
         {menuOpen ? (
           <X size={24} aria-hidden="true" />

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -228,6 +228,81 @@
   margin: 0;
 }
 
+.settings__theme-row {
+  padding: var(--spacing-lg) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings__theme-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.settings__theme-legend {
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  color: var(--color-text-primary);
+  padding: 0;
+  margin-bottom: var(--spacing-sm);
+}
+
+.settings__theme-options {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.settings__theme-option {
+  flex: 1 1 0;
+  min-width: 6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.settings__theme-option:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-border-hover);
+}
+
+.settings__theme-option--selected {
+  border-color: var(--color-text-primary);
+  background-color: var(--color-surface-hover);
+}
+
+.settings__theme-option:focus-within {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.settings__theme-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.settings__theme-option-label {
+  font-size: var(--font-size-base);
+}
+
 .settings__language-row {
   display: flex;
   flex-direction: column;

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -6,6 +6,7 @@ import { Settings } from './Settings'
 import type { LocaleCode } from '../../locale/types'
 import { renderWithProviders } from '../../test/utils/render-helpers'
 import * as languageStorage from '../../services/languageStorage'
+import * as themeStorage from '../../services/themeStorage'
 import { openDB, getAllHabits } from '../../services/indexedDB'
 
 vi.mock('../../services/indexedDB', () => ({
@@ -50,6 +51,8 @@ describe('Settings', () => {
     vi.mocked(getAllHabits).mockResolvedValue([])
     vi.mocked(languageStorage.getPreferredLanguage).mockResolvedValue('en')
     vi.mocked(languageStorage.setPreferredLanguage).mockResolvedValue(undefined)
+    vi.spyOn(themeStorage, 'getPreferredTheme').mockResolvedValue(undefined)
+    vi.spyOn(themeStorage, 'setPreferredTheme').mockResolvedValue(undefined)
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -61,6 +64,8 @@ describe('Settings', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    document.documentElement.removeAttribute('data-theme')
   })
 
   async function renderReady(
@@ -258,6 +263,45 @@ describe('Settings', () => {
 
     expect(screen.getByRole('navigation')).toBeInTheDocument()
     expect(screen.getByRole('list')).toBeInTheDocument()
+  })
+
+  it('should render theme radio group with three options', async () => {
+    await renderReady(<Settings onClose={() => {}} />)
+
+    const group = screen.getByRole('radiogroup', { name: 'Theme' })
+    expect(group).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'Light' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'Dark' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'System' })).toBeInTheDocument()
+  })
+
+  it('should persist theme and set data-theme attribute when user picks Dark', async () => {
+    const user = userEvent.setup()
+    await renderReady(<Settings onClose={() => {}} />)
+
+    await user.click(screen.getByRole('radio', { name: 'Dark' }))
+
+    expect(themeStorage.setPreferredTheme).toHaveBeenCalledWith('dark')
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    })
+  })
+
+  it('should remove data-theme attribute when user picks System', async () => {
+    const user = userEvent.setup()
+    await renderReady(<Settings onClose={() => {}} />)
+
+    await user.click(screen.getByRole('radio', { name: 'Light' }))
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    })
+
+    await user.click(screen.getByRole('radio', { name: 'System' }))
+
+    expect(themeStorage.setPreferredTheme).toHaveBeenLastCalledWith('system')
+    await waitFor(() => {
+      expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+    })
   })
 
   it('should show changelog load error when fetch fails', async () => {

--- a/src/components/Settings/Settings.test.tsx
+++ b/src/components/Settings/Settings.test.tsx
@@ -268,7 +268,7 @@ describe('Settings', () => {
   it('should render theme radio group with three options', async () => {
     await renderReady(<Settings onClose={() => {}} />)
 
-    const group = screen.getByRole('radiogroup', { name: 'Theme' })
+    const group = screen.getByRole('group', { name: 'Theme' })
     expect(group).toBeInTheDocument()
     expect(within(group).getByRole('radio', { name: 'Light' })).toBeInTheDocument()
     expect(within(group).getByRole('radio', { name: 'Dark' })).toBeInTheDocument()
@@ -287,20 +287,21 @@ describe('Settings', () => {
     })
   })
 
-  it('should remove data-theme attribute when user picks System', async () => {
+  it('should persist system and resolve data-theme attribute when user picks System', async () => {
     const user = userEvent.setup()
     await renderReady(<Settings onClose={() => {}} />)
 
-    await user.click(screen.getByRole('radio', { name: 'Light' }))
+    await user.click(screen.getByRole('radio', { name: 'Dark' }))
     await waitFor(() => {
-      expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
     })
 
     await user.click(screen.getByRole('radio', { name: 'System' }))
 
     expect(themeStorage.setPreferredTheme).toHaveBeenLastCalledWith('system')
     await waitFor(() => {
-      expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+      const attr = document.documentElement.getAttribute('data-theme')
+      expect(attr === 'light' || attr === 'dark').toBe(true)
     })
   })
 

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -21,7 +21,6 @@ export function Settings({ onClose }: SettingsProps) {
   const [panel, setPanel] = useState<SettingsPanel>('list')
   const settingsRef = useRef<HTMLDivElement>(null)
   const settingsTitleId = useId()
-  const themeLegendId = useId()
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -83,18 +82,11 @@ export function Settings({ onClose }: SettingsProps) {
       <nav className="settings__nav">
         <ul className="settings__list">
           <li className="settings__theme-row">
-            <fieldset
-              className="settings__theme-fieldset"
-              aria-labelledby={themeLegendId}
-            >
-              <legend id={themeLegendId} className="settings__theme-legend">
+            <fieldset className="settings__theme-fieldset">
+              <legend className="settings__theme-legend">
                 {messages.settings.theme.title}
               </legend>
-              <div
-                className="settings__theme-options"
-                role="radiogroup"
-                aria-label={messages.settings.theme.ariaLabel}
-              >
+              <div className="settings__theme-options">
                 {THEME_OPTIONS.map((option) => (
                   <label
                     key={option}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useId, useRef, useState } from 'react'
 import { ChevronRight, ChevronLeft } from 'lucide-react'
 import { useLanguage } from '../../contexts/LanguageContext'
+import { useTheme } from '../../contexts/ThemeContext'
 import type { LocaleCode } from '../../locale/types'
+import type { ThemePreference } from '../../services/themeStorage'
 import { SettingsChangelogPanel } from './SettingsChangelogPanel'
 import './Settings.css'
+
+const THEME_OPTIONS: readonly ThemePreference[] = ['light', 'dark', 'system']
 
 interface SettingsProps {
   onClose: () => void
@@ -13,9 +17,11 @@ type SettingsPanel = 'list' | 'changelog'
 
 export function Settings({ onClose }: SettingsProps) {
   const { messages, locale, setLanguage, supportedLanguages } = useLanguage()
+  const { theme, setTheme } = useTheme()
   const [panel, setPanel] = useState<SettingsPanel>('list')
   const settingsRef = useRef<HTMLDivElement>(null)
   const settingsTitleId = useId()
+  const themeLegendId = useId()
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -76,6 +82,44 @@ export function Settings({ onClose }: SettingsProps) {
       </header>
       <nav className="settings__nav">
         <ul className="settings__list">
+          <li className="settings__theme-row">
+            <fieldset
+              className="settings__theme-fieldset"
+              aria-labelledby={themeLegendId}
+            >
+              <legend id={themeLegendId} className="settings__theme-legend">
+                {messages.settings.theme.title}
+              </legend>
+              <div
+                className="settings__theme-options"
+                role="radiogroup"
+                aria-label={messages.settings.theme.ariaLabel}
+              >
+                {THEME_OPTIONS.map((option) => (
+                  <label
+                    key={option}
+                    className={`settings__theme-option${
+                      theme === option ? ' settings__theme-option--selected' : ''
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="preferred-theme"
+                      value={option}
+                      checked={theme === option}
+                      onChange={() => {
+                        void setTheme(option)
+                      }}
+                      className="settings__theme-radio"
+                    />
+                    <span className="settings__theme-option-label">
+                      {messages.settings.theme[option]}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          </li>
           <li className="settings__language-row">
             <label
               className="settings__language-label"

--- a/src/components/SideMenu/SideMenu.css
+++ b/src/components/SideMenu/SideMenu.css
@@ -72,11 +72,8 @@
   font-weight: 500;
 }
 
-/* Only when system or app is not forcing light; matches index.css system/dark theming. */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']) .side-menu__backdrop {
-    background-color: rgba(0, 0, 0, 0.5);
-  }
+:root[data-theme='dark'] .side-menu__backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
 }
 
 @media (max-width: 600px) {

--- a/src/components/SideMenu/SideMenu.css
+++ b/src/components/SideMenu/SideMenu.css
@@ -72,8 +72,9 @@
   font-weight: 500;
 }
 
+/* Only when system or app is not forcing light; matches index.css system/dark theming. */
 @media (prefers-color-scheme: dark) {
-  .side-menu__backdrop {
+  :root:not([data-theme='light']) .side-menu__backdrop {
     background-color: rgba(0, 0, 0, 0.5);
   }
 }

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -103,6 +103,7 @@ export function SideMenu({ isOpen, onClose, activeView, onNavigate }: SideMenuPr
       )}
       <nav
         ref={menuRef}
+        id="side-menu"
         className={`side-menu ${isOpen ? 'side-menu--open' : ''}`}
         role="navigation"
         aria-label={messages.sideMenu.navigationAria}

--- a/src/components/Statistics/StatisticsView.css
+++ b/src/components/Statistics/StatisticsView.css
@@ -28,3 +28,24 @@
     font-size: var(--font-size-2xl);
   }
 }
+
+@media (min-width: 768px) {
+  .statistics-view {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    max-width: none;
+    width: 100%;
+    margin: var(--spacing-3xl) 0;
+    gap: var(--spacing-lg);
+    align-items: start;
+  }
+
+  .statistics-view__title,
+  .statistics-view__empty {
+    grid-column: 1 / -1;
+  }
+
+  .statistics-view .habit-stats-card {
+    margin-bottom: 0;
+  }
+}

--- a/src/components/habit/AnnualCalendar/AnnualCalendar.css
+++ b/src/components/habit/AnnualCalendar/AnnualCalendar.css
@@ -68,26 +68,51 @@
   opacity: 0.2;
 }
 
+/* App dark: must apply even when the OS is in light mode (no dark media). */
+:root[data-theme='dark'] .annual-calendar-day {
+  background-color: #21262d;
+  border-color: rgba(240, 246, 252, 0.1);
+}
+
+:root[data-theme='dark'] .annual-calendar-day.completed {
+  background-color: #26a641;
+  border-color: transparent;
+}
+
+:root[data-theme='dark'] .annual-calendar-day.completed:hover {
+  background-color: #39d353;
+}
+
+:root[data-theme='dark'] .annual-calendar-day.today {
+  border-color: #58a6ff;
+}
+
+:root[data-theme='dark'] .annual-calendar-day.today.completed {
+  background-color: #26a641;
+  border-color: #58a6ff;
+}
+
+/* System theme + OS dark: do not apply when the app forces light. */
 @media (prefers-color-scheme: dark) {
-  .annual-calendar-day {
+  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day {
     background-color: #21262d;
     border-color: rgba(240, 246, 252, 0.1);
   }
 
-  .annual-calendar-day.completed {
+  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.completed {
     background-color: #26a641;
     border-color: transparent;
   }
 
-  .annual-calendar-day.completed:hover {
+  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.completed:hover {
     background-color: #39d353;
   }
 
-  .annual-calendar-day.today {
+  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.today {
     border-color: #58a6ff;
   }
 
-  .annual-calendar-day.today.completed {
+  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.today.completed {
     background-color: #26a641;
     border-color: #58a6ff;
   }

--- a/src/components/habit/AnnualCalendar/AnnualCalendar.css
+++ b/src/components/habit/AnnualCalendar/AnnualCalendar.css
@@ -68,7 +68,7 @@
   opacity: 0.2;
 }
 
-/* App dark: must apply even when the OS is in light mode (no dark media). */
+/* ThemeProvider sets data-theme to the resolved value ('light' or 'dark'). */
 :root[data-theme='dark'] .annual-calendar-day {
   background-color: #21262d;
   border-color: rgba(240, 246, 252, 0.1);
@@ -90,32 +90,6 @@
 :root[data-theme='dark'] .annual-calendar-day.today.completed {
   background-color: #26a641;
   border-color: #58a6ff;
-}
-
-/* System theme + OS dark: do not apply when the app forces light. */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day {
-    background-color: #21262d;
-    border-color: rgba(240, 246, 252, 0.1);
-  }
-
-  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.completed {
-    background-color: #26a641;
-    border-color: transparent;
-  }
-
-  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.completed:hover {
-    background-color: #39d353;
-  }
-
-  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.today {
-    border-color: #58a6ff;
-  }
-
-  :root:not([data-theme='light']):not([data-theme='dark']) .annual-calendar-day.today.completed {
-    background-color: #26a641;
-    border-color: #58a6ff;
-  }
 }
 
 @media (max-width: 1200px) {

--- a/src/components/habit/HabitList/HabitList.css
+++ b/src/components/habit/HabitList/HabitList.css
@@ -3,7 +3,7 @@
   padding: 0;
   margin: var(--spacing-3xl) 0;
   width: 100%;
-  max-width: 800px;
+  max-width: 600px;
 }
 
 .habit-list > .empty-state {
@@ -199,6 +199,25 @@
   .habit-actions {
     gap: var(--spacing-sm);
     margin-top: var(--spacing-md);
+  }
+}
+
+@media (min-width: 768px) {
+  .habit-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    max-width: none;
+    width: 100%;
+    gap: var(--spacing-lg);
+    align-items: start;
+  }
+
+  .habit-list > p {
+    grid-column: 1 / -1;
+  }
+
+  .habit-item {
+    margin-bottom: 0;
   }
 }
 

--- a/src/components/habit/StreakBadge/StreakBadge.css
+++ b/src/components/habit/StreakBadge/StreakBadge.css
@@ -44,19 +44,6 @@
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .streak-badge-simple {
-    background-color: var(--color-primary-light);
-    color: var(--color-primary);
-    border-color: var(--color-primary);
-  }
-
-  .streak-badge-colorful {
-    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-success) 100%);
-    color: var(--color-button-primary-text);
-  }
-}
-
 @media (max-width: 600px) {
   .streak-badge {
     font-size: var(--font-size-xs);

--- a/src/components/pwa/ServiceWorkerUpdatePrompt/ServiceWorkerUpdatePrompt.css
+++ b/src/components/pwa/ServiceWorkerUpdatePrompt/ServiceWorkerUpdatePrompt.css
@@ -3,6 +3,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
+  margin: var(--spacing-lg) 0;
   background-color: var(--color-warning-bg);
   color: var(--color-on-warning);
   border: 1px solid var(--color-warning-border);
@@ -13,7 +14,7 @@
   top: calc(var(--spacing-md) + env(safe-area-inset-top));
   left: 50%;
   transform: translateX(-50%);
-  z-index: var(--z-index-indicator);
+  z-index: var(--z-index-modal);
   box-shadow: var(--shadow-md);
   animation: sw-update-slideDown var(--transition-base) ease-out;
 }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -41,13 +41,9 @@ function getSystemResolvedTheme(): ResolvedTheme {
   return window.matchMedia(DARK_MEDIA_QUERY).matches ? 'dark' : 'light'
 }
 
-function applyThemeAttribute(theme: ThemePreference): void {
+function applyThemeAttribute(resolved: ResolvedTheme): void {
   if (typeof document === 'undefined') return
-  if (theme === 'system') {
-    document.documentElement.removeAttribute('data-theme')
-  } else {
-    document.documentElement.setAttribute('data-theme', theme)
-  }
+  document.documentElement.setAttribute('data-theme', resolved)
 }
 
 interface ThemeProviderProps {
@@ -65,11 +61,14 @@ export function ThemeProvider({ children, initialTheme }: ThemeProviderProps) {
   )
   const mountedRef = useRef(true)
 
+  const resolvedTheme: ResolvedTheme = theme === 'system' ? systemResolved : theme
+
   useEffect(() => {
-    if (initialTheme !== undefined) {
-      applyThemeAttribute(initialTheme)
-      return
-    }
+    applyThemeAttribute(resolvedTheme)
+  }, [resolvedTheme])
+
+  useEffect(() => {
+    if (initialTheme !== undefined) return
 
     mountedRef.current = true
 
@@ -78,7 +77,6 @@ export function ThemeProvider({ children, initialTheme }: ThemeProviderProps) {
         const stored = await getPreferredTheme()
         if (mountedRef.current && stored !== undefined) {
           setThemeState(stored)
-          applyThemeAttribute(stored)
         }
       } catch {
         // fall back to 'system'; no-op
@@ -105,11 +103,8 @@ export function ThemeProvider({ children, initialTheme }: ThemeProviderProps) {
 
   const setTheme = useCallback(async (next: ThemePreference) => {
     setThemeState(next)
-    applyThemeAttribute(next)
     await persistPreferredTheme(next)
   }, [])
-
-  const resolvedTheme: ResolvedTheme = theme === 'system' ? systemResolved : theme
 
   const value = useMemo(
     (): ThemeContextValue => ({ theme, resolvedTheme, setTheme }),

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,120 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  getPreferredTheme,
+  setPreferredTheme as persistPreferredTheme,
+  type ThemePreference,
+} from '../services/themeStorage'
+
+type ResolvedTheme = 'light' | 'dark'
+
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)'
+
+interface ThemeContextValue {
+  theme: ThemePreference
+  resolvedTheme: ResolvedTheme
+  setTheme: (theme: ThemePreference) => Promise<void>
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (ctx === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return ctx
+}
+
+function getSystemResolvedTheme(): ResolvedTheme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light'
+  }
+  return window.matchMedia(DARK_MEDIA_QUERY).matches ? 'dark' : 'light'
+}
+
+function applyThemeAttribute(theme: ThemePreference): void {
+  if (typeof document === 'undefined') return
+  if (theme === 'system') {
+    document.documentElement.removeAttribute('data-theme')
+  } else {
+    document.documentElement.setAttribute('data-theme', theme)
+  }
+}
+
+interface ThemeProviderProps {
+  children: ReactNode
+  /** When set, skips IndexedDB and initializes synchronously (tests). */
+  initialTheme?: ThemePreference
+}
+
+export function ThemeProvider({ children, initialTheme }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemePreference>(
+    () => initialTheme ?? 'system'
+  )
+  const [systemResolved, setSystemResolved] = useState<ResolvedTheme>(() =>
+    getSystemResolvedTheme()
+  )
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    if (initialTheme !== undefined) {
+      applyThemeAttribute(initialTheme)
+      return
+    }
+
+    mountedRef.current = true
+
+    async function init() {
+      try {
+        const stored = await getPreferredTheme()
+        if (mountedRef.current && stored !== undefined) {
+          setThemeState(stored)
+          applyThemeAttribute(stored)
+        }
+      } catch {
+        // fall back to 'system'; no-op
+      }
+    }
+
+    void init()
+    return () => {
+      mountedRef.current = false
+    }
+  }, [initialTheme])
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+    const mql = window.matchMedia(DARK_MEDIA_QUERY)
+    const handleChange = (e: MediaQueryListEvent) => {
+      setSystemResolved(e.matches ? 'dark' : 'light')
+    }
+    mql.addEventListener('change', handleChange)
+    return () => mql.removeEventListener('change', handleChange)
+  }, [])
+
+  const setTheme = useCallback(async (next: ThemePreference) => {
+    setThemeState(next)
+    applyThemeAttribute(next)
+    await persistPreferredTheme(next)
+  }, [])
+
+  const resolvedTheme: ResolvedTheme = theme === 'system' ? systemResolved : theme
+
+  const value = useMemo(
+    (): ThemeContextValue => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/src/index.css
+++ b/src/index.css
@@ -83,7 +83,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme='light']):not([data-theme='dark']) {
     /* Colors - Dark Mode */
     --color-background: #1e1e1e;
     --color-surface: #1e1e1e;
@@ -93,12 +93,12 @@
     --color-text-tertiary: #808080;
     --color-border: #333333;
     --color-border-hover: #404040;
-    
+
     /* Primary Colors */
     --color-primary: #42a5f5;
     --color-primary-hover: #64b5f6;
     --color-primary-light: #1e3a5f;
-    
+
     /* Semantic Colors */
     --color-success: #66bb6a;
     --color-success-bg: #1b5e20;
@@ -113,7 +113,7 @@
     --color-on-warning-muted: #f5f5f5;
     --color-on-warning-outline: rgba(255, 255, 255, 0.72);
     --color-on-warning-dismiss-hover-bg: rgba(255, 255, 255, 0.14);
-    
+
     /* Interactive Elements */
     --color-button-primary-text: #000000;
     --color-button-secondary-bg: #2a2a2a;
@@ -122,14 +122,62 @@
     --color-button-secondary-border: #404040;
     --color-disabled-bg: #2a2a2a;
     --color-disabled-text: #666666;
-    
+
     /* Focus */
     --color-focus: #42a5f5;
-    
+
     /* Shadows */
     --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
   }
+}
+
+:root[data-theme='dark'] {
+  /* Colors - Dark Mode */
+  --color-background: #1e1e1e;
+  --color-surface: #1e1e1e;
+  --color-surface-hover: #2a2a2a;
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #b0b0b0;
+  --color-text-tertiary: #808080;
+  --color-border: #333333;
+  --color-border-hover: #404040;
+
+  /* Primary Colors */
+  --color-primary: #42a5f5;
+  --color-primary-hover: #64b5f6;
+  --color-primary-light: #1e3a5f;
+
+  /* Semantic Colors */
+  --color-success: #66bb6a;
+  --color-success-bg: #1b5e20;
+  --color-success-border: #2e7d32;
+  --color-error: #ef5350;
+  --color-error-bg: #b71c1c;
+  --color-error-border: #c62828;
+  --color-warning: #ff9800;
+  --color-warning-bg: #e65100;
+  --color-warning-border: #ff9800;
+  --color-on-warning: #ffffff;
+  --color-on-warning-muted: #f5f5f5;
+  --color-on-warning-outline: rgba(255, 255, 255, 0.72);
+  --color-on-warning-dismiss-hover-bg: rgba(255, 255, 255, 0.14);
+
+  /* Interactive Elements */
+  --color-button-primary-text: #000000;
+  --color-button-secondary-bg: #2a2a2a;
+  --color-button-secondary-hover: #333333;
+  --color-button-secondary-text: #e0e0e0;
+  --color-button-secondary-border: #404040;
+  --color-disabled-bg: #2a2a2a;
+  --color-disabled-text: #666666;
+
+  /* Focus */
+  --color-focus: #42a5f5;
+
+  /* Shadows */
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
 
 * {

--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,9 @@
   
   /* Focus */
   --color-focus: #0066cc;
+
+  /* App header mask logo (can diverge from body text) */
+  --app-header-logo-fill: var(--color-text-primary);
   
   /* Shadows */
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -126,10 +129,16 @@
     /* Focus */
     --color-focus: #42a5f5;
 
+    --app-header-logo-fill: var(--color-text-primary);
+
     /* Shadows */
     --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
   }
+}
+
+:root[data-theme='light'] {
+  --app-header-logo-fill: var(--color-text-primary);
 }
 
 :root[data-theme='dark'] {
@@ -174,6 +183,8 @@
 
   /* Focus */
   --color-focus: #42a5f5;
+
+  --app-header-logo-fill: var(--color-text-primary);
 
   /* Shadows */
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);

--- a/src/index.css
+++ b/src/index.css
@@ -29,8 +29,8 @@
   --color-on-warning-outline: rgba(0, 0, 0, 0.28);
   --color-on-warning-dismiss-hover-bg: rgba(0, 0, 0, 0.06);
   
-  /* Interactive Elements */
-  --color-button-primary-text: #000000;
+  /* Text on --color-primary (black) */
+  --color-button-primary-text: #ffffff;
   --color-button-secondary-bg: #f5f5f5;
   --color-button-secondary-hover: #e0e0e0;
   --color-button-secondary-text: #333333;
@@ -197,6 +197,19 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--color-background);
   color: var(--color-text-primary);
+}
+
+/* Light UIs: body was forced `antialiased`, which on many systems looks soft/muddy on light backdrops. Logs round2: html `auto`, body `antialiased` while data-theme=light. */
+:root[data-theme='light'] body {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme='dark']) body {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+  }
 }
 
 #root {

--- a/src/index.css
+++ b/src/index.css
@@ -85,64 +85,9 @@
   --z-index-modal: 1000;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme='light']):not([data-theme='dark']) {
-    /* Colors - Dark Mode */
-    --color-background: #1e1e1e;
-    --color-surface: #1e1e1e;
-    --color-surface-hover: #2a2a2a;
-    --color-text-primary: #e0e0e0;
-    --color-text-secondary: #b0b0b0;
-    --color-text-tertiary: #808080;
-    --color-border: #333333;
-    --color-border-hover: #404040;
-
-    /* Primary Colors */
-    --color-primary: #42a5f5;
-    --color-primary-hover: #64b5f6;
-    --color-primary-light: #1e3a5f;
-
-    /* Semantic Colors */
-    --color-success: #66bb6a;
-    --color-success-bg: #1b5e20;
-    --color-success-border: #2e7d32;
-    --color-error: #ef5350;
-    --color-error-bg: #b71c1c;
-    --color-error-border: #c62828;
-    --color-warning: #ff9800;
-    --color-warning-bg: #e65100;
-    --color-warning-border: #ff9800;
-    --color-on-warning: #ffffff;
-    --color-on-warning-muted: #f5f5f5;
-    --color-on-warning-outline: rgba(255, 255, 255, 0.72);
-    --color-on-warning-dismiss-hover-bg: rgba(255, 255, 255, 0.14);
-
-    /* Interactive Elements */
-    --color-button-primary-text: #000000;
-    --color-button-secondary-bg: #2a2a2a;
-    --color-button-secondary-hover: #333333;
-    --color-button-secondary-text: #e0e0e0;
-    --color-button-secondary-border: #404040;
-    --color-disabled-bg: #2a2a2a;
-    --color-disabled-text: #666666;
-
-    /* Focus */
-    --color-focus: #42a5f5;
-
-    --app-header-logo-fill: var(--color-text-primary);
-
-    /* Shadows */
-    --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
-    --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
-  }
-}
-
-:root[data-theme='light'] {
-  --app-header-logo-fill: var(--color-text-primary);
-}
-
+/* ThemeProvider sets data-theme to the resolved value ('light' or 'dark'),
+   so these tokens cover both explicit user choice and system default. */
 :root[data-theme='dark'] {
-  /* Colors - Dark Mode */
   --color-background: #1e1e1e;
   --color-surface: #1e1e1e;
   --color-surface-hover: #2a2a2a;
@@ -152,12 +97,10 @@
   --color-border: #333333;
   --color-border-hover: #404040;
 
-  /* Primary Colors */
   --color-primary: #42a5f5;
   --color-primary-hover: #64b5f6;
   --color-primary-light: #1e3a5f;
 
-  /* Semantic Colors */
   --color-success: #66bb6a;
   --color-success-bg: #1b5e20;
   --color-success-border: #2e7d32;
@@ -172,7 +115,6 @@
   --color-on-warning-outline: rgba(255, 255, 255, 0.72);
   --color-on-warning-dismiss-hover-bg: rgba(255, 255, 255, 0.14);
 
-  /* Interactive Elements */
   --color-button-primary-text: #000000;
   --color-button-secondary-bg: #2a2a2a;
   --color-button-secondary-hover: #333333;
@@ -181,12 +123,10 @@
   --color-disabled-bg: #2a2a2a;
   --color-disabled-text: #666666;
 
-  /* Focus */
   --color-focus: #42a5f5;
 
   --app-header-logo-fill: var(--color-text-primary);
 
-  /* Shadows */
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
@@ -210,17 +150,10 @@ body {
   color: var(--color-text-primary);
 }
 
-/* Light UIs: body was forced `antialiased`, which on many systems looks soft/muddy on light backdrops. Logs round2: html `auto`, body `antialiased` while data-theme=light. */
+/* `antialiased` looks soft/muddy on light backdrops on many systems. */
 :root[data-theme='light'] body {
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
-}
-
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme='dark']) body {
-    -webkit-font-smoothing: auto;
-    -moz-osx-font-smoothing: auto;
-  }
 }
 
 #root {

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -176,6 +176,13 @@ export const en = {
     changelogLoadError: 'Could not load changelog. Check your connection and try again.',
     changelogRetry: 'Try again',
     changelogExternalLinkSuffix: ', opens in new tab',
+    theme: {
+      title: 'Theme',
+      light: 'Light',
+      dark: 'Dark',
+      system: 'System',
+      ariaLabel: 'Theme',
+    },
     items: {
       changelog: 'Changelog',
     },

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -181,7 +181,6 @@ export const en = {
       light: 'Light',
       dark: 'Dark',
       system: 'System',
-      ariaLabel: 'Theme',
     },
     items: {
       changelog: 'Changelog',

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -178,6 +178,13 @@ export const ptBR = {
       'Não foi possível carregar as atualizações. Verifique a conexão e tente novamente.',
     changelogRetry: 'Tentar novamente',
     changelogExternalLinkSuffix: ', abre em nova aba',
+    theme: {
+      title: 'Tema',
+      light: 'Claro',
+      dark: 'Escuro',
+      system: 'Sistema',
+      ariaLabel: 'Tema',
+    },
     items: {
       changelog: 'Atualizações',
     },

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -183,7 +183,6 @@ export const ptBR = {
       light: 'Claro',
       dark: 'Escuro',
       system: 'Sistema',
-      ariaLabel: 'Tema',
     },
     items: {
       changelog: 'Atualizações',

--- a/src/services/themeStorage.ts
+++ b/src/services/themeStorage.ts
@@ -1,0 +1,22 @@
+import { getSetting, setSetting } from './indexedDB'
+
+export type ThemePreference = 'light' | 'dark' | 'system'
+
+const PREFERRED_THEME_KEY = 'preferredTheme'
+
+const THEME_VALUES: readonly ThemePreference[] = ['light', 'dark', 'system']
+
+function isThemePreference(value: string): value is ThemePreference {
+  return (THEME_VALUES as readonly string[]).includes(value)
+}
+
+export async function getPreferredTheme(): Promise<ThemePreference | undefined> {
+  const raw = await getSetting(PREFERRED_THEME_KEY)
+  if (raw === undefined) return undefined
+  return isThemePreference(raw) ? raw : undefined
+}
+
+export async function setPreferredTheme(theme: ThemePreference): Promise<void> {
+  if (!isThemePreference(theme)) return
+  await setSetting(PREFERRED_THEME_KEY, theme)
+}

--- a/src/services/themeStorage.ts
+++ b/src/services/themeStorage.ts
@@ -17,6 +17,14 @@ export async function getPreferredTheme(): Promise<ThemePreference | undefined> 
 }
 
 export async function setPreferredTheme(theme: ThemePreference): Promise<void> {
-  if (!isThemePreference(theme)) return
+  // Mirror to localStorage so the inline script in index.html can apply the
+  // theme synchronously on next load and avoid a flash of the wrong theme.
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem(PREFERRED_THEME_KEY, theme)
+    }
+  } catch {
+    // Safari private mode / disabled storage: ignore, IndexedDB is source of truth.
+  }
   await setSetting(PREFERRED_THEME_KEY, theme)
 }

--- a/src/test/utils/render-helpers.tsx
+++ b/src/test/utils/render-helpers.tsx
@@ -2,23 +2,32 @@ import { ReactElement, ReactNode, Component, ErrorInfo } from 'react'
 import { render, RenderOptions } from '@testing-library/react'
 import { HabitProvider } from '../../contexts/HabitContext'
 import { LanguageProvider } from '../../contexts/LanguageContext'
+import { ThemeProvider } from '../../contexts/ThemeContext'
 import type { LocaleCode } from '../../locale/types'
+import type { ThemePreference } from '../../services/themeStorage'
 
 type CustomRenderOptions = Omit<RenderOptions, 'wrapper'> & {
   initialLocale?: LocaleCode
+  initialTheme?: ThemePreference
 }
 
 export function renderWithProviders(
   ui: ReactElement,
   options?: CustomRenderOptions
 ) {
-  const { initialLocale = 'en', ...renderOptions } = options ?? {}
+  const {
+    initialLocale = 'en',
+    initialTheme = 'system',
+    ...renderOptions
+  } = options ?? {}
 
   function Wrapper({ children }: { children: ReactNode }) {
     return (
-      <LanguageProvider initialLocale={initialLocale}>
-        <HabitProvider>{children}</HabitProvider>
-      </LanguageProvider>
+      <ThemeProvider initialTheme={initialTheme}>
+        <LanguageProvider initialLocale={initialLocale}>
+          <HabitProvider>{children}</HabitProvider>
+        </LanguageProvider>
+      </ThemeProvider>
     )
   }
 

--- a/src/theme/lightModePrimaryContrast.test.ts
+++ b/src/theme/lightModePrimaryContrast.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { getContrastRatio, meetsWCAGAA } from '../utils/accessibility/contrastRatio'
+
+/**
+ * Light theme tokens in src/index.css :root — primary buttons use
+ * background --color-primary and color --color-button-primary-text.
+ * Regression: both were #000000 so labels were invisible (solid black controls).
+ */
+describe('light mode primary button tokens', () => {
+  const LIGHT_PRIMARY = '#000000'
+  const LIGHT_ON_PRIMARY = '#ffffff'
+
+  it('on-primary text contrasts with black primary (WCAG AA)', () => {
+    const ratio = getContrastRatio(LIGHT_PRIMARY, LIGHT_ON_PRIMARY)
+    expect(ratio).toBeGreaterThan(4.5)
+    expect(meetsWCAGAA(ratio, false)).toBe(true)
+  })
+
+  it('on-primary is not the same as fill (1:1 would hide label)', () => {
+    expect(LIGHT_PRIMARY).not.toBe(LIGHT_ON_PRIMARY)
+  })
+})

--- a/src/theme/lightModePrimaryContrast.test.ts
+++ b/src/theme/lightModePrimaryContrast.test.ts
@@ -1,22 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import { getContrastRatio, meetsWCAGAA } from '../utils/accessibility/contrastRatio'
 
 /**
- * Light theme tokens in src/index.css :root — primary buttons use
- * background --color-primary and color --color-button-primary-text.
- * Regression: both were #000000 so labels were invisible (solid black controls).
+ * Regression: light-theme primary button background and on-primary text were
+ * both #000000, making button labels invisible. Parse the actual CSS tokens so
+ * a future token change can't silently reintroduce the bug.
  */
 describe('light mode primary button tokens', () => {
-  const LIGHT_PRIMARY = '#000000'
-  const LIGHT_ON_PRIMARY = '#ffffff'
+  const here = dirname(fileURLToPath(import.meta.url))
+  const indexCss = readFileSync(resolve(here, '../index.css'), 'utf-8')
 
-  it('on-primary text contrasts with black primary (WCAG AA)', () => {
-    const ratio = getContrastRatio(LIGHT_PRIMARY, LIGHT_ON_PRIMARY)
+  const rootBlock = indexCss.match(/:root\s*\{([\s\S]*?)\}/)?.[1] ?? ''
+
+  function readVar(name: string): string {
+    const match = rootBlock.match(new RegExp(`--${name}:\\s*([^;]+);`))
+    const value = match?.[1]
+    if (!value) throw new Error(`Could not find --${name} in :root block`)
+    return value.trim()
+  }
+
+  const lightPrimary = readVar('color-primary')
+  const lightOnPrimary = readVar('color-button-primary-text')
+
+  it('on-primary text contrasts with primary (WCAG AA)', () => {
+    const ratio = getContrastRatio(lightPrimary, lightOnPrimary)
     expect(ratio).toBeGreaterThan(4.5)
     expect(meetsWCAGAA(ratio, false)).toBe(true)
   })
 
-  it('on-primary is not the same as fill (1:1 would hide label)', () => {
-    expect(LIGHT_PRIMARY).not.toBe(LIGHT_ON_PRIMARY)
+  it('on-primary is not the same as the fill (1:1 would hide the label)', () => {
+    expect(lightPrimary.toLowerCase()).not.toBe(lightOnPrimary.toLowerCase())
   })
 })


### PR DESCRIPTION
## Description
* Added user-controlled theme toggle (light/dark/system) in Settings with `data-theme` override honored across components
* Made the app header logo a home link with a theme-aware mask, and restored header blur on Safari
* Introduced a responsive grid layout for habits and statistics on wider screens (≥768px)
* Lifted the service worker update prompt above other overlays with proper vertical spacing

## Screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)