### PR TITLE
chore(claude): enable frontend-design plugin in shared settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## Summary
* Adds `.claude/settings.json` to the repo with the `frontend-design@claude-plugins-official` plugin enabled
* Shares the Claude Code plugin configuration across contributors working on this repo
* Keeps `.claude/settings.local.json` gitignored so personal permissions stay local

## Test plan
- [x] `.claude/settings.local.json` remains untracked (gitignored)
- [x] Only `.claude/settings.json` is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)