### PR TITLE
fix(habits): align habit cards to equal heights in grid

### DIFF
--- a/src/components/habit/HabitList/HabitList.css
+++ b/src/components/habit/HabitList/HabitList.css
@@ -209,7 +209,7 @@
     max-width: none;
     width: 100%;
     gap: var(--spacing-lg);
-    align-items: start;
+    align-items: stretch;
   }
 
   .habit-list > p {
@@ -218,6 +218,12 @@
 
   .habit-item {
     margin-bottom: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .habit-item .habit-actions {
+    margin-top: auto;
   }
 }
 


### PR DESCRIPTION
## Description
* Stretches habit cards in the grid layout so all cards in a row share the same height
* Pins each card's action area to the bottom via `margin-top: auto` for consistent alignment
* Produces a tidier, more uniform grid on wider screens regardless of note/description length

## Screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)