### PR TITLE
fix(statistics): align statistic cards to equal heights in grid

### DIFF
--- a/src/components/Statistics/HabitStatisticsCard.css
+++ b/src/components/Statistics/HabitStatisticsCard.css
@@ -6,6 +6,12 @@
   margin-bottom: var(--spacing-lg);
   box-shadow: var(--shadow-sm);
   transition: box-shadow var(--transition-base), border-color var(--transition-base);
+  display: flex;
+  flex-direction: column;
+}
+
+.habit-stats-card > :last-child {
+  margin-top: auto;
 }
 
 .habit-stats-card:hover {

--- a/src/components/Statistics/StatisticsView.css
+++ b/src/components/Statistics/StatisticsView.css
@@ -37,7 +37,7 @@
     width: 100%;
     margin: var(--spacing-3xl) 0;
     gap: var(--spacing-lg);
-    align-items: start;
+    align-items: stretch;
   }
 
   .statistics-view__title,


### PR DESCRIPTION
## Summary
* All statistic cards on the Estatísticas page now share the same height within a row, regardless of title wrapping or optional goal-progress section
* Applies the same CSS-only pattern used in the habit list grid (#167): grid uses `align-items: stretch`, card becomes a flex column with its last child (annual heatmap) pinned to the bottom via `margin-top: auto`
* No TSX changes — purely visual consistency fix

## Test plan
- [ ] Open Estatísticas view at desktop width (≥768px) and confirm all cards in a row end at the same bottom edge
- [ ] Verify cards with two-line titles (e.g., "Meta de focus e pausas seguidas") align with single-line siblings
- [ ] Verify cards without "Progresso da meta" match the height of cards that have it
- [ ] Resize below 768px to confirm single-column stacking is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)