### PR TITLE
Habit list: reorder by drag-and-drop with layout-aware sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4308,9 +4308,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "habit-tracker",
       "version": "0.4.3",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "lucide-react": "^0.555.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -825,6 +828,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -7797,6 +7853,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "lucide-react": "^0.555.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/habit/HabitForm/HabitForm.tsx
+++ b/src/components/habit/HabitForm/HabitForm.tsx
@@ -5,6 +5,7 @@ import { addHabit, updateHabit } from '../../../services/indexedDB'
 import { track } from '../../../analytics/umami'
 import type { Habit } from '../../../types/habit'
 import { MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from '../../../utils/validation/validateHabit'
+import { nextSortOrderForNewHabit } from '../../../utils/habit/nextSortOrderForNewHabit'
 import { StackingHabitsSelector } from '../StackingHabitsSelector/StackingHabitsSelector'
 import './HabitForm.css'
 
@@ -109,6 +110,7 @@ export function HabitForm({ habit, onSuccess, onCancel }: HabitFormProps) {
         stackingStepLabels: labelsForStack && Object.keys(labelsForStack).length > 0 ? labelsForStack : undefined,
         autoCompletedDates: hasStacking ? habit?.autoCompletedDates : undefined,
         goalDays: goalDays.length > 0 ? goalDays : undefined,
+        sortOrder: isEditMode ? habit?.sortOrder : nextSortOrderForNewHabit(habits),
       }
 
       if (isEditMode) {

--- a/src/components/habit/HabitList/HabitList.css
+++ b/src/components/habit/HabitList/HabitList.css
@@ -1,3 +1,21 @@
+.habit-list-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+}
+
+.habit-list__sr-announcement {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .habit-list {
   list-style: none;
   padding: 0;
@@ -43,6 +61,43 @@
   margin-bottom: var(--spacing-md);
   flex-wrap: wrap;
   gap: var(--spacing-sm);
+}
+
+.habit-header--with-handle {
+  align-items: center;
+}
+
+.habit-drag-handle {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs);
+  margin: calc(-1 * var(--spacing-xs)) var(--spacing-sm) calc(-1 * var(--spacing-xs)) calc(-1 * var(--spacing-xs));
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: grab;
+  border-radius: var(--radius-sm);
+  touch-action: none;
+}
+
+.habit-drag-handle:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-border-hover, rgba(0, 0, 0, 0.04));
+}
+
+.habit-drag-handle:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.habit-drag-handle:active {
+  cursor: grabbing;
+}
+
+.habit-item--dragging {
+  box-shadow: var(--shadow-md);
 }
 
 .habit-name {

--- a/src/components/habit/HabitList/HabitList.css
+++ b/src/components/habit/HabitList/HabitList.css
@@ -72,8 +72,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-xs);
-  margin: calc(-1 * var(--spacing-xs)) var(--spacing-sm) calc(-1 * var(--spacing-xs)) calc(-1 * var(--spacing-xs));
+  padding: var(--spacing-sm);
+  margin: calc(-1 * var(--spacing-sm)) var(--spacing-sm) calc(-1 * var(--spacing-sm)) calc(-1 * var(--spacing-sm));
   border: none;
   background: transparent;
   color: var(--color-text-secondary);

--- a/src/components/habit/HabitList/HabitList.css
+++ b/src/components/habit/HabitList/HabitList.css
@@ -258,6 +258,10 @@
 }
 
 @media (min-width: 768px) {
+  .habit-list-wrapper {
+    max-width: none;
+  }
+
   .habit-list {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));

--- a/src/components/habit/HabitList/HabitList.test.tsx
+++ b/src/components/habit/HabitList/HabitList.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../../services/indexedDB', () => ({
   getAllHabits: vi.fn(),
   updateHabit: vi.fn(),
   deleteHabit: vi.fn(),
+  putHabits: vi.fn(),
   testUtils: {
     resetDB: vi.fn(),
   },
@@ -65,6 +66,20 @@ describe('HabitList', () => {
     expect(await screen.findByText('Daily workout')).toBeInTheDocument()
     expect(await screen.findByText('Read')).toBeInTheDocument()
     expect(await screen.findByText('Read for 30 minutes')).toBeInTheDocument()
+  })
+
+  it('renders reorder drag handles with accessible names', async () => {
+    const habits = [
+      createMockHabit({ id: '1', name: 'Exercise' }),
+      createMockHabit({ id: '2', name: 'Read' }),
+    ]
+
+    vi.mocked(getAllHabits).mockResolvedValue(habits)
+
+    renderWithProviders(<HabitList />)
+
+    expect(await screen.findByRole('button', { name: /^reorder exercise$/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /^reorder read$/i })).toBeInTheDocument()
   })
 
   it('should display streak badge for each habit', async () => {

--- a/src/components/habit/HabitList/HabitList.tsx
+++ b/src/components/habit/HabitList/HabitList.tsx
@@ -1,4 +1,14 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useRef, useCallback } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useHabits } from '../../../contexts/HabitContext'
 import { useLanguage } from '../../../contexts/LanguageContext'
 import { formatMessage } from '../../../locale'
@@ -6,10 +16,8 @@ import { calculateStreak } from '../../../utils/habit/calculateStreak'
 import { isTodayCompleted } from '../../../utils/habit/isTodayCompleted'
 import { getHabitsToPersistAfterStackingToggle } from '../../../utils/habit/stackingCompletionCoordinator'
 import { archiveHabit } from '../../../utils/habit/archiveHabit'
-import { HabitStackingAccordion } from '../HabitStackingAccordion/HabitStackingAccordion'
 import { ConfirmationModal } from '../../modal/ConfirmationModal/ConfirmationModal'
-import { StreakBadge } from '../StreakBadge/StreakBadge'
-import { GoalBadge } from '../GoalBadge/GoalBadge'
+import { SortableHabitItem } from './SortableHabitItem'
 import type { Habit } from '../../../types/habit'
 import './HabitList.css'
 
@@ -19,10 +27,22 @@ interface HabitListProps {
 
 export function HabitList({ onEdit }: HabitListProps) {
   const { messages } = useLanguage()
-  const { habits, activeHabits, isLoading, error, toggleHabitCompletion, updateHabit } = useHabits()
+  const { habits, activeHabits, isLoading, error, toggleHabitCompletion, updateHabit, reorderActiveHabits } =
+    useHabits()
   const [togglingId, setTogglingId] = useState<string | null>(null)
   const [archivingId, setArchivingId] = useState<string | null>(null)
   const [habitToArchive, setHabitToArchive] = useState<{ id: string; name?: string } | null>(null)
+  const [reorderAnnouncement, setReorderAnnouncement] = useState<string | null>(null)
+  const announcementClearRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
 
   const habitsWithCalculations = useMemo(() => {
     return activeHabits.map(habit => ({
@@ -31,6 +51,38 @@ export function HabitList({ onEdit }: HabitListProps) {
       completedToday: isTodayCompleted(habit.completionDates),
     }))
   }, [activeHabits])
+
+  const sortableItemIds = useMemo(() => habitsWithCalculations.map(h => h.id), [habitsWithCalculations])
+
+  const scheduleClearAnnouncement = useCallback(() => {
+    if (announcementClearRef.current !== null) {
+      globalThis.clearTimeout(announcementClearRef.current)
+    }
+    announcementClearRef.current = globalThis.setTimeout(() => {
+      setReorderAnnouncement(null)
+      announcementClearRef.current = null
+    }, 3000)
+  }, [])
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) {
+      return
+    }
+    const oldIndex = sortableItemIds.indexOf(String(active.id))
+    const newIndex = sortableItemIds.indexOf(String(over.id))
+    if (oldIndex === -1 || newIndex === -1) {
+      return
+    }
+    const nextOrder = arrayMove(sortableItemIds, oldIndex, newIndex)
+    try {
+      await reorderActiveHabits(nextOrder)
+      setReorderAnnouncement(messages.habitList.reorderAnnouncement)
+      scheduleClearAnnouncement()
+    } catch {
+      // Error surfaced via HabitContext
+    }
+  }
 
   const handleToggle = async (habitId: string) => {
     setTogglingId(habitId)
@@ -124,64 +176,31 @@ export function HabitList({ onEdit }: HabitListProps) {
         onCancel={handleArchiveCancel}
         isConfirming={archivingId !== null}
       />
-      <ul className="habit-list" aria-label={messages.habitList.aria.list}>
-        {habitsWithCalculations.map(habit => (
-          <li key={habit.id} className="habit-item">
-            <div className="habit-header">
-              <h3 className="habit-name">{habit.name || messages.habitList.unnamedHabit}</h3>
-              <StreakBadge streak={habit.streak} />
-              {habit.goalDays !== undefined && habit.goalDays.length > 0 && (
-                <GoalBadge goalDays={habit.goalDays} completionDates={habit.completionDates} />
-              )}
-            </div>
-            {habit.description && (
-              <p className="habit-description">{habit.description}</p>
-            )}
-            {habit.stackingHabits && habit.stackingHabits.length > 0 && (
-              <HabitStackingAccordion
-                parentHabit={habit}
-                stackingHabitsResolved={habit.stackingHabits.map(id => habits.find(h => h.id === id))}
-                onToggleStackingHabit={handleToggleStackingHabit}
-                updateHabit={updateHabit}
-              />
-            )}
-            <div className="habit-actions">
-              <button
-                type="button"
-                className={`completion-toggle ${habit.completedToday ? 'completed' : 'not-completed'}`}
-                onClick={() => handleToggle(habit.id)}
-                disabled={togglingId === habit.id}
-                aria-label={habit.completedToday ? messages.habitList.aria.markNotCompleted : messages.habitList.aria.markCompleted}
-                aria-pressed={habit.completedToday}
-                aria-busy={togglingId === habit.id}
-              >
-                {togglingId === habit.id ? messages.habitList.buttons.updating : habit.completedToday ? messages.habitList.buttons.completed : messages.habitList.buttons.markDone}
-              </button>
-              {onEdit && (
-                <button
-                  type="button"
-                  className="habit-edit-button"
-                  onClick={() => onEdit(habit)}
-                  aria-label={formatMessage(messages.habitList.aria.editHabit, { name: habit.name || messages.habitList.aria.habitNameFallback })}
-                >
-                  {messages.habitList.buttons.edit}
-                </button>
-              )}
-              <button
-                type="button"
-                className="habit-archive-button"
-                onClick={() => handleArchiveClick(habit.id, habit.name)}
-                disabled={archivingId === habit.id}
-                aria-label={formatMessage(messages.habitList.aria.archiveHabit, { name: habit.name || messages.habitList.aria.habitNameFallback })}
-                aria-busy={archivingId === habit.id}
-              >
-                {messages.habitList.buttons.archive}
-              </button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <div className="habit-list-wrapper">
+        <div className="habit-list__sr-announcement" role="status" aria-live="polite" aria-atomic="true">
+          {reorderAnnouncement}
+        </div>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={sortableItemIds} strategy={verticalListSortingStrategy}>
+            <ul className="habit-list" aria-label={messages.habitList.aria.list}>
+              {habitsWithCalculations.map(habit => (
+                <SortableHabitItem
+                  key={habit.id}
+                  habit={habit}
+                  habits={habits}
+                  togglingId={togglingId}
+                  archivingId={archivingId}
+                  onEdit={onEdit}
+                  onToggle={handleToggle}
+                  onArchiveClick={handleArchiveClick}
+                  onToggleStackingHabit={handleToggleStackingHabit}
+                  updateHabit={updateHabit}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      </div>
     </>
   )
 }
-

--- a/src/components/habit/HabitList/HabitList.tsx
+++ b/src/components/habit/HabitList/HabitList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef, useCallback } from 'react'
+import { useMemo, useState, useRef, useCallback, useSyncExternalStore } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -8,7 +8,13 @@ import {
   useSensors,
   type DragEndEvent,
 } from '@dnd-kit/core'
-import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  rectSortingStrategy,
+} from '@dnd-kit/sortable'
 import { useHabits } from '../../../contexts/HabitContext'
 import { useLanguage } from '../../../contexts/LanguageContext'
 import { formatMessage } from '../../../locale'
@@ -23,6 +29,29 @@ import './HabitList.css'
 
 interface HabitListProps {
   onEdit?: (habit: Habit) => void
+}
+
+/** Matches `HabitList.css` @media (min-width: 768px) grid layout. */
+const GRID_LAYOUT_MEDIA_QUERY = '(min-width: 768px)'
+
+function subscribeGridLayoutMatch(onChange: () => void) {
+  if (typeof globalThis.matchMedia !== 'function') {
+    return () => {}
+  }
+  const mq = globalThis.matchMedia(GRID_LAYOUT_MEDIA_QUERY)
+  mq.addEventListener('change', onChange)
+  return () => mq.removeEventListener('change', onChange)
+}
+
+function getGridLayoutMatchSnapshot() {
+  if (typeof globalThis.matchMedia !== 'function') {
+    return false
+  }
+  return globalThis.matchMedia(GRID_LAYOUT_MEDIA_QUERY).matches
+}
+
+function getGridLayoutMatchServerSnapshot() {
+  return false
 }
 
 export function HabitList({ onEdit }: HabitListProps) {
@@ -54,6 +83,13 @@ export function HabitList({ onEdit }: HabitListProps) {
 
   const sortableItemIds = useMemo(() => habitsWithCalculations.map(h => h.id), [habitsWithCalculations])
 
+  const useGridSortableStrategy = useSyncExternalStore(
+    subscribeGridLayoutMatch,
+    getGridLayoutMatchSnapshot,
+    getGridLayoutMatchServerSnapshot
+  )
+  const sortableStrategy = useGridSortableStrategy ? rectSortingStrategy : verticalListSortingStrategy
+
   const scheduleClearAnnouncement = useCallback(() => {
     if (announcementClearRef.current !== null) {
       globalThis.clearTimeout(announcementClearRef.current)
@@ -64,25 +100,28 @@ export function HabitList({ onEdit }: HabitListProps) {
     }, 3000)
   }, [])
 
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) {
-      return
-    }
-    const oldIndex = sortableItemIds.indexOf(String(active.id))
-    const newIndex = sortableItemIds.indexOf(String(over.id))
-    if (oldIndex === -1 || newIndex === -1) {
-      return
-    }
-    const nextOrder = arrayMove(sortableItemIds, oldIndex, newIndex)
-    try {
-      await reorderActiveHabits(nextOrder)
-      setReorderAnnouncement(messages.habitList.reorderAnnouncement)
-      scheduleClearAnnouncement()
-    } catch {
-      // Error surfaced via HabitContext
-    }
-  }
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) {
+        return
+      }
+      const oldIndex = sortableItemIds.indexOf(String(active.id))
+      const newIndex = sortableItemIds.indexOf(String(over.id))
+      if (oldIndex === -1 || newIndex === -1) {
+        return
+      }
+      const nextOrder = arrayMove(sortableItemIds, oldIndex, newIndex)
+      try {
+        await reorderActiveHabits(nextOrder)
+        setReorderAnnouncement(messages.habitList.reorderAnnouncement)
+        scheduleClearAnnouncement()
+      } catch {
+        // Error surfaced via HabitContext
+      }
+    },
+    [sortableItemIds, reorderActiveHabits, messages.habitList.reorderAnnouncement, scheduleClearAnnouncement]
+  )
 
   const handleToggle = async (habitId: string) => {
     setTogglingId(habitId)
@@ -181,7 +220,7 @@ export function HabitList({ onEdit }: HabitListProps) {
           {reorderAnnouncement}
         </div>
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={sortableItemIds} strategy={verticalListSortingStrategy}>
+          <SortableContext items={sortableItemIds} strategy={sortableStrategy}>
             <ul className="habit-list" aria-label={messages.habitList.aria.list}>
               {habitsWithCalculations.map(habit => (
                 <SortableHabitItem

--- a/src/components/habit/HabitList/SortableHabitItem.tsx
+++ b/src/components/habit/HabitList/SortableHabitItem.tsx
@@ -1,0 +1,132 @@
+import type { CSSProperties } from 'react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { GripVertical } from 'lucide-react'
+import { useLanguage } from '../../../contexts/LanguageContext'
+import { formatMessage } from '../../../locale'
+import { HabitStackingAccordion } from '../HabitStackingAccordion/HabitStackingAccordion'
+import { StreakBadge } from '../StreakBadge/StreakBadge'
+import { GoalBadge } from '../GoalBadge/GoalBadge'
+import type { Habit } from '../../../types/habit'
+
+export type HabitWithListFields = Habit & { streak: number; completedToday: boolean }
+
+interface SortableHabitItemProps {
+  habit: HabitWithListFields
+  habits: Habit[]
+  togglingId: string | null
+  archivingId: string | null
+  onEdit?: (habit: Habit) => void
+  onToggle: (habitId: string) => void
+  onArchiveClick: (habitId: string, habitName?: string) => void
+  onToggleStackingHabit: (parentHabitId: string, stackingHabitId: string) => Promise<void>
+  updateHabit: (habit: Habit) => Promise<void>
+}
+
+export function SortableHabitItem({
+  habit,
+  habits,
+  togglingId,
+  archivingId,
+  onEdit,
+  onToggle,
+  onArchiveClick,
+  onToggleStackingHabit,
+  updateHabit,
+}: SortableHabitItemProps) {
+  const { messages } = useLanguage()
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
+    id: habit.id,
+  })
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    position: 'relative',
+    zIndex: isDragging ? 1 : undefined,
+    opacity: isDragging ? 0.92 : undefined,
+  }
+
+  const handleLabel = formatMessage(messages.habitList.aria.reorderHandle, {
+    name: habit.name || messages.habitList.aria.habitNameFallback,
+  })
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`habit-item${isDragging ? ' habit-item--dragging' : ''}`}
+      {...attributes}
+      role="listitem"
+    >
+      <div className="habit-header habit-header--with-handle">
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          className="habit-drag-handle"
+          {...listeners}
+          aria-label={handleLabel}
+        >
+          <GripVertical size={20} aria-hidden />
+        </button>
+        <h3 className="habit-name">{habit.name || messages.habitList.unnamedHabit}</h3>
+        <StreakBadge streak={habit.streak} />
+        {habit.goalDays !== undefined && habit.goalDays.length > 0 && (
+          <GoalBadge goalDays={habit.goalDays} completionDates={habit.completionDates} />
+        )}
+      </div>
+      {habit.description && <p className="habit-description">{habit.description}</p>}
+      {habit.stackingHabits && habit.stackingHabits.length > 0 && (
+        <HabitStackingAccordion
+          parentHabit={habit}
+          stackingHabitsResolved={habit.stackingHabits.map(id => habits.find(h => h.id === id))}
+          onToggleStackingHabit={onToggleStackingHabit}
+          updateHabit={updateHabit}
+        />
+      )}
+      <div className="habit-actions">
+        <button
+          type="button"
+          className={`completion-toggle ${habit.completedToday ? 'completed' : 'not-completed'}`}
+          onClick={() => onToggle(habit.id)}
+          disabled={togglingId === habit.id}
+          aria-label={
+            habit.completedToday ? messages.habitList.aria.markNotCompleted : messages.habitList.aria.markCompleted
+          }
+          aria-pressed={habit.completedToday}
+          aria-busy={togglingId === habit.id}
+        >
+          {togglingId === habit.id
+            ? messages.habitList.buttons.updating
+            : habit.completedToday
+              ? messages.habitList.buttons.completed
+              : messages.habitList.buttons.markDone}
+        </button>
+        {onEdit && (
+          <button
+            type="button"
+            className="habit-edit-button"
+            onClick={() => onEdit(habit)}
+            aria-label={formatMessage(messages.habitList.aria.editHabit, {
+              name: habit.name || messages.habitList.aria.habitNameFallback,
+            })}
+          >
+            {messages.habitList.buttons.edit}
+          </button>
+        )}
+        <button
+          type="button"
+          className="habit-archive-button"
+          onClick={() => onArchiveClick(habit.id, habit.name)}
+          disabled={archivingId === habit.id}
+          aria-label={formatMessage(messages.habitList.aria.archiveHabit, {
+            name: habit.name || messages.habitList.aria.habitNameFallback,
+          })}
+          aria-busy={archivingId === habit.id}
+        >
+          {messages.habitList.buttons.archive}
+        </button>
+      </div>
+    </li>
+  )
+}

--- a/src/contexts/HabitContext.test.tsx
+++ b/src/contexts/HabitContext.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { useHabits } from './HabitContext'
-import { openDB, getAllHabits, updateHabit, deleteHabit } from '../services/indexedDB'
+import { openDB, getAllHabits, updateHabit, deleteHabit, putHabits } from '../services/indexedDB'
 import { testUtils } from '../services/indexedDB'
 import { createMockHabit } from '../test/fixtures/habits'
 import { createDateString } from '../test/utils/date-helpers'
@@ -13,6 +14,7 @@ vi.mock('../services/indexedDB', () => ({
   getAllHabits: vi.fn(),
   updateHabit: vi.fn(),
   deleteHabit: vi.fn(),
+  putHabits: vi.fn(),
   testUtils: {
     resetDB: vi.fn(),
   },
@@ -519,6 +521,59 @@ describe('HabitContext', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('archived-ids').textContent).toBe('2')
+      })
+    })
+
+    it('sorts activeHabits by sortOrder', async () => {
+      const mockHabits = [
+        createMockHabit({ id: 'a', name: 'Third', sortOrder: 2, createdDate: '2020-01-01T00:00:00.000Z' }),
+        createMockHabit({ id: 'b', name: 'First', sortOrder: 0, createdDate: '2020-01-01T00:00:00.000Z' }),
+        createMockHabit({ id: 'c', name: 'Second', sortOrder: 1, createdDate: '2020-01-01T00:00:00.000Z' }),
+      ]
+      vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+      vi.mocked(getAllHabits).mockResolvedValue(mockHabits)
+
+      renderWithProviders(<TestDerivedLists />)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('active-ids').textContent).toBe('b,c,a')
+      })
+    })
+  })
+
+  describe('reorderActiveHabits', () => {
+    function TestReorder() {
+      const { reorderActiveHabits } = useHabits()
+      return (
+        <button type="button" onClick={() => void reorderActiveHabits(['2', '1'])}>
+          reorder
+        </button>
+      )
+    }
+
+    it('calls putHabits with updated sortOrder and refreshes', async () => {
+      const user = userEvent.setup()
+      const initial = [
+        createMockHabit({ id: '1', name: 'A', sortOrder: 0, createdDate: '2020-01-01T00:00:00.000Z' }),
+        createMockHabit({ id: '2', name: 'B', sortOrder: 1, createdDate: '2020-01-02T00:00:00.000Z' }),
+      ]
+      vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+      vi.mocked(getAllHabits).mockResolvedValue(initial)
+      vi.mocked(putHabits).mockResolvedValue(undefined)
+
+      renderWithProviders(<TestReorder />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /reorder/i })).toBeEnabled()
+      })
+
+      await user.click(screen.getByRole('button', { name: /reorder/i }))
+
+      await waitFor(() => {
+        expect(putHabits).toHaveBeenCalledWith([
+          expect.objectContaining({ id: '2', sortOrder: 0 }),
+          expect.objectContaining({ id: '1', sortOrder: 1 }),
+        ])
       })
     })
   })

--- a/src/contexts/HabitContext.test.tsx
+++ b/src/contexts/HabitContext.test.tsx
@@ -542,10 +542,10 @@ describe('HabitContext', () => {
   })
 
   describe('reorderActiveHabits', () => {
-    function TestReorder() {
+    function TestReorder({ ids }: { ids: string[] }) {
       const { reorderActiveHabits } = useHabits()
       return (
-        <button type="button" onClick={() => void reorderActiveHabits(['2', '1'])}>
+        <button type="button" onClick={() => void reorderActiveHabits(ids)}>
           reorder
         </button>
       )
@@ -561,7 +561,7 @@ describe('HabitContext', () => {
       vi.mocked(getAllHabits).mockResolvedValue(initial)
       vi.mocked(putHabits).mockResolvedValue(undefined)
 
-      renderWithProviders(<TestReorder />)
+      renderWithProviders(<TestReorder ids={['2', '1']} />)
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /reorder/i })).toBeEnabled()
@@ -575,6 +575,78 @@ describe('HabitContext', () => {
           expect.objectContaining({ id: '1', sortOrder: 1 }),
         ])
       })
+    })
+
+    it('returns early when orderedIds length does not match active habits count', async () => {
+      const user = userEvent.setup()
+      const initial = [
+        createMockHabit({ id: '1', name: 'A', sortOrder: 0 }),
+        createMockHabit({ id: '2', name: 'B', sortOrder: 1 }),
+      ]
+      vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+      vi.mocked(getAllHabits).mockResolvedValue(initial)
+      vi.mocked(putHabits).mockResolvedValue(undefined)
+
+      renderWithProviders(<TestReorder ids={['1']} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /reorder/i })).toBeEnabled()
+      })
+
+      await user.click(screen.getByRole('button', { name: /reorder/i }))
+
+      await waitFor(() => {
+        expect(getAllHabits).toHaveBeenCalled()
+      })
+      expect(putHabits).not.toHaveBeenCalled()
+    })
+
+    it('returns early when orderedIds contains an id not in the active set', async () => {
+      const user = userEvent.setup()
+      const initial = [
+        createMockHabit({ id: '1', name: 'A', sortOrder: 0 }),
+        createMockHabit({ id: '2', name: 'B', sortOrder: 1 }),
+      ]
+      vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+      vi.mocked(getAllHabits).mockResolvedValue(initial)
+      vi.mocked(putHabits).mockResolvedValue(undefined)
+
+      renderWithProviders(<TestReorder ids={['1', 'bogus']} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /reorder/i })).toBeEnabled()
+      })
+
+      await user.click(screen.getByRole('button', { name: /reorder/i }))
+
+      await waitFor(() => {
+        expect(getAllHabits).toHaveBeenCalled()
+      })
+      expect(putHabits).not.toHaveBeenCalled()
+    })
+
+    it('returns early when sortOrder would be unchanged', async () => {
+      const user = userEvent.setup()
+      const initial = [
+        createMockHabit({ id: '1', name: 'A', sortOrder: 0 }),
+        createMockHabit({ id: '2', name: 'B', sortOrder: 1 }),
+      ]
+      vi.mocked(openDB).mockResolvedValue({} as IDBDatabase)
+      vi.mocked(getAllHabits).mockResolvedValue(initial)
+      vi.mocked(putHabits).mockResolvedValue(undefined)
+
+      renderWithProviders(<TestReorder ids={['1', '2']} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /reorder/i })).toBeEnabled()
+      })
+
+      await user.click(screen.getByRole('button', { name: /reorder/i }))
+
+      await waitFor(() => {
+        expect(getAllHabits).toHaveBeenCalled()
+      })
+      expect(putHabits).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/contexts/HabitContext.tsx
+++ b/src/contexts/HabitContext.tsx
@@ -1,12 +1,13 @@
 import { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
 import { useLanguage } from './LanguageContext'
-import { openDB, getAllHabits, updateHabit as updateHabitInDB, deleteHabit as deleteHabitFromDB } from '../services/indexedDB'
+import { openDB, getAllHabits, updateHabit as updateHabitInDB, deleteHabit as deleteHabitFromDB, putHabits } from '../services/indexedDB'
 import { runMigrations, migrations } from '../services/migration'
 import { toggleCompletion } from '../utils/habit/toggleCompletion'
 import { stripTodayFromAutoCompletedDates } from '../utils/habit/checkAutoCompletion'
 import { createAppError } from '../utils/error/errorTypes'
 import { logError } from '../utils/error/errorLogger'
 import type { Habit } from '../types/habit'
+import { sortHabitsByDisplayOrder } from '../utils/habit/sortHabitsByDisplayOrder'
 
 interface HabitContextType {
   habits: Habit[]
@@ -18,6 +19,7 @@ interface HabitContextType {
   toggleHabitCompletion: (habitId: string) => Promise<void>
   updateHabit: (habit: Habit) => Promise<void>
   deleteHabit: (habitId: string) => Promise<void>
+  reorderActiveHabits: (orderedIds: string[]) => Promise<void>
 }
 
 const HabitContext = createContext<HabitContextType | undefined>(undefined)
@@ -114,6 +116,46 @@ export function HabitProvider({ children }: HabitProviderProps) {
     }
   }, [messages.app.deleteHabitError, refreshHabits])
 
+  const reorderActiveHabits = useCallback(
+    async (orderedIds: string[]) => {
+      try {
+        setError(null)
+        const active = habits.filter(h => !h.archivedAt)
+        if (orderedIds.length !== active.length) {
+          return
+        }
+        const activeIdSet = new Set(active.map(h => h.id))
+        if (!orderedIds.every(id => activeIdSet.has(id))) {
+          return
+        }
+        const byId = new Map(habits.map(h => [h.id, h]))
+        const updated: Habit[] = orderedIds.map((id, index) => {
+          const h = byId.get(id)
+          if (!h) {
+            throw new Error(`Habit ${id} not found`)
+          }
+          return { ...h, sortOrder: index }
+        })
+        const anyChanged = updated.some(h => byId.get(h.id)?.sortOrder !== h.sortOrder)
+        if (!anyChanged) {
+          return
+        }
+        await putHabits(updated)
+        await refreshHabits()
+      } catch (err) {
+        const appError = createAppError(
+          err,
+          'UNKNOWN_ERROR',
+          messages.app.updateHabitError
+        )
+        logError(appError)
+        setError(appError.userMessage)
+        throw err
+      }
+    },
+    [habits, messages.app.updateHabitError, refreshHabits]
+  )
+
   useEffect(() => {
     async function initializeApp() {
       try {
@@ -138,8 +180,14 @@ export function HabitProvider({ children }: HabitProviderProps) {
     initializeApp()
   }, [messages.app.initError, refreshHabits])
 
-  const activeHabits = useMemo(() => habits.filter(h => !h.archivedAt), [habits])
-  const archivedHabits = useMemo(() => habits.filter(h => !!h.archivedAt), [habits])
+  const activeHabits = useMemo(() => {
+    const active = habits.filter(h => !h.archivedAt)
+    return sortHabitsByDisplayOrder(active)
+  }, [habits])
+  const archivedHabits = useMemo(() => {
+    const archived = habits.filter(h => !!h.archivedAt)
+    return sortHabitsByDisplayOrder(archived)
+  }, [habits])
 
   const value: HabitContextType = useMemo(
     () => ({
@@ -152,8 +200,20 @@ export function HabitProvider({ children }: HabitProviderProps) {
       toggleHabitCompletion,
       updateHabit,
       deleteHabit,
+      reorderActiveHabits,
     }),
-    [habits, activeHabits, archivedHabits, isLoading, error, refreshHabits, toggleHabitCompletion, updateHabit, deleteHabit]
+    [
+      habits,
+      activeHabits,
+      archivedHabits,
+      isLoading,
+      error,
+      refreshHabits,
+      toggleHabitCompletion,
+      updateHabit,
+      deleteHabit,
+      reorderActiveHabits,
+    ]
   )
 
   return <HabitContext.Provider value={value}>{children}</HabitContext.Provider>

--- a/src/locale/messages/en.ts
+++ b/src/locale/messages/en.ts
@@ -67,6 +67,7 @@ export const en = {
     empty: 'No habits yet. Start by creating your first habit!',
     unnamedHabit: 'Unnamed Habit',
     thisHabit: 'this habit',
+    reorderAnnouncement: 'Habit order saved.',
     buttons: {
       markDone: 'Mark as done',
       completed: '✓ Completed',
@@ -83,6 +84,7 @@ export const en = {
       archiveHabit: 'Archive {name}',
       habitNameFallback: 'habit',
       list: 'List of habits',
+      reorderHandle: 'Reorder {name}',
     },
     deleteModal: {
       title: 'Delete Habit',

--- a/src/locale/messages/pt-BR.ts
+++ b/src/locale/messages/pt-BR.ts
@@ -67,6 +67,7 @@ export const ptBR = {
     empty: 'Ainda não há hábitos. Comece criando seu primeiro hábito!',
     unnamedHabit: 'Hábito Sem Nome',
     thisHabit: 'este hábito',
+    reorderAnnouncement: 'Ordem dos hábitos salva.',
     buttons: {
       markDone: 'Marcar como feito',
       completed: '✓ Concluído',
@@ -83,6 +84,7 @@ export const ptBR = {
       archiveHabit: 'Arquivar {name}',
       habitNameFallback: 'hábito',
       list: 'Lista de hábitos',
+      reorderHandle: 'Reordenar {name}',
     },
     deleteModal: {
       title: 'Excluir Hábito',

--- a/src/services/indexedDB.test.ts
+++ b/src/services/indexedDB.test.ts
@@ -6,6 +6,7 @@ import {
   getAllHabits,
   updateHabit,
   deleteHabit,
+  putHabits,
   closeDB,
   testUtils,
 } from './indexedDB'
@@ -321,6 +322,35 @@ describe('IndexedDB Service', () => {
       await triggerIDBRequestError(getAllRequest, error)
 
       await expect(getAllPromise).rejects.toThrow('Unable to access storage. Please refresh the page.')
+    })
+  })
+
+  describe('putHabits', () => {
+    beforeEach(async () => {
+      await setupMockDB()
+      ;(mockObjectStore.put as ReturnType<typeof vi.fn>).mockReturnValue(createMockIDBRequest<string>())
+    })
+
+    it('puts all habits and resolves when the transaction completes', async () => {
+      const h1 = createMockHabit({ id: '1', name: 'A', sortOrder: 0 })
+      const h2 = createMockHabit({ id: '2', name: 'B', sortOrder: 1 })
+
+      const promise = putHabits([h1, h2])
+      await Promise.resolve()
+      if (mockTransaction.oncomplete) {
+        ;(mockTransaction.oncomplete as () => void)()
+      }
+      await promise
+
+      expect(mockObjectStore.put).toHaveBeenCalledTimes(2)
+      expect(mockObjectStore.put).toHaveBeenNthCalledWith(1, h1)
+      expect(mockObjectStore.put).toHaveBeenNthCalledWith(2, h2)
+    })
+
+    it('resolves immediately when the list is empty', async () => {
+      await setupMockDB()
+      await expect(putHabits([])).resolves.toBeUndefined()
+      expect(mockDB.transaction).not.toHaveBeenCalled()
     })
   })
 

--- a/src/services/indexedDB.ts
+++ b/src/services/indexedDB.ts
@@ -279,6 +279,36 @@ export async function updateHabit(habit: Habit): Promise<string> {
   return String(result)
 }
 
+/**
+ * Writes multiple habits in a single IndexedDB transaction (e.g. batch sortOrder updates).
+ */
+export async function putHabits(habits: Habit[]): Promise<void> {
+  if (habits.length === 0) return
+  for (const h of habits) {
+    validateHabit(h)
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    openDB()
+      .then((db) => {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          reject(new Error(`Object store "${STORE_NAME}" does not exist`))
+          return
+        }
+        const transaction = db.transaction([STORE_NAME], 'readwrite')
+        const objectStore = transaction.objectStore(STORE_NAME)
+        transaction.oncomplete = () => resolve()
+        transaction.onerror = () => {
+          reject(transaction.error ?? new Error('Transaction failed'))
+        }
+        for (const habit of habits) {
+          objectStore.put(habit)
+        }
+      })
+      .catch(reject)
+  })
+}
+
 export async function deleteHabit(id: string): Promise<void> {
   validateId(id)
 

--- a/src/services/migration/migrationRunner.test.ts
+++ b/src/services/migration/migrationRunner.test.ts
@@ -9,6 +9,7 @@ import {
 import type { Migration } from './types'
 import type { Habit } from '../../types/habit'
 import { createMockHabit } from '../../test/fixtures/habits'
+import { migrations as appMigrations } from './migrations'
 
 function createMockStoreBackedByMap(data: Map<string, unknown>) {
   return {
@@ -325,6 +326,26 @@ describe('Migration Runner', () => {
 
     it('handles missing backup gracefully', async () => {
       await expect(restoreFromBackup(mockDB)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('app migration backfill-sort-order', () => {
+    it('assigns contiguous sortOrder by createdDate then id', async () => {
+      habitsData.clear()
+      habitsData.set(
+        'b',
+        createMockHabit({ id: 'b', name: 'Second', createdDate: '2025-02-01T00:00:00.000Z' })
+      )
+      habitsData.set(
+        'a',
+        createMockHabit({ id: 'a', name: 'First', createdDate: '2025-01-01T00:00:00.000Z' })
+      )
+      const migration = appMigrations.find(m => m.name === 'backfill-sort-order')
+      expect(migration).toBeDefined()
+      await migration!.migrate(mockDB)
+      const byId = new Map((Array.from(habitsData.values()) as Habit[]).map(h => [h.id, h]))
+      expect(byId.get('a')?.sortOrder).toBe(0)
+      expect(byId.get('b')?.sortOrder).toBe(1)
     })
   })
 

--- a/src/services/migration/migrationRunner.ts
+++ b/src/services/migration/migrationRunner.ts
@@ -37,7 +37,7 @@ function settingsPut(db: IDBDatabase, key: string, value: string): Promise<void>
   })
 }
 
-function habitsGetAll(db: IDBDatabase): Promise<Habit[]> {
+export function habitsGetAll(db: IDBDatabase): Promise<Habit[]> {
   return new Promise((resolve, reject) => {
     const transaction = db.transaction([STORE_NAME], 'readonly')
     const store = transaction.objectStore(STORE_NAME)
@@ -50,7 +50,7 @@ function habitsGetAll(db: IDBDatabase): Promise<Habit[]> {
   })
 }
 
-function habitsClearAndRestore(db: IDBDatabase, habits: Habit[]): Promise<void> {
+export function habitsClearAndRestore(db: IDBDatabase, habits: Habit[]): Promise<void> {
   return new Promise((resolve, reject) => {
     const transaction = db.transaction([STORE_NAME], 'readwrite')
     const store = transaction.objectStore(STORE_NAME)

--- a/src/services/migration/migrations.ts
+++ b/src/services/migration/migrations.ts
@@ -1,3 +1,22 @@
+import type { Habit } from '../../types/habit'
 import type { Migration } from './types'
+import { habitsGetAll, habitsClearAndRestore } from './migrationRunner'
 
-export const migrations: Migration[] = []
+function compareCreatedDateThenId(a: Habit, b: Habit): number {
+  const byDate = a.createdDate.localeCompare(b.createdDate)
+  if (byDate !== 0) return byDate
+  return a.id.localeCompare(b.id)
+}
+
+export const migrations: Migration[] = [
+  {
+    version: 1,
+    name: 'backfill-sort-order',
+    async migrate(db) {
+      const habits = await habitsGetAll(db)
+      const sorted = [...habits].sort(compareCreatedDateThenId)
+      const withSortOrder = sorted.map((h, index) => ({ ...h, sortOrder: index }))
+      await habitsClearAndRestore(db, withSortOrder)
+    },
+  },
+]

--- a/src/types/habit.ts
+++ b/src/types/habit.ts
@@ -11,6 +11,7 @@
  * @property stackingStepLabels - Optional map of stacking-step ID to display name; used when that ID is not in the main habits list (stacking-only steps)
  * @property autoCompletedDates - Optional array of ISO 8601 date strings for days the main habit was marked complete only because all stacked steps were done that day (not manual main completion)
  * @property archivedAt - Optional ISO 8601 date string marking when the habit was archived; undefined means the habit is active
+ * @property sortOrder - Optional non-negative display order among all habits; lower values appear first. Assigned on create and by migration; updated when reordering.
  *
  * Constraints:
  * - id must be a non-empty string
@@ -30,5 +31,6 @@ export interface Habit {
   autoCompletedDates?: string[]
   goalDays?: number[]
   archivedAt?: string
+  sortOrder?: number
 }
 

--- a/src/utils/habit/nextSortOrderForNewHabit.test.ts
+++ b/src/utils/habit/nextSortOrderForNewHabit.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { nextSortOrderForNewHabit } from './nextSortOrderForNewHabit'
+import type { Habit } from '../../types/habit'
+
+const h = (overrides: Partial<Habit>): Habit => ({
+  id: '1',
+  createdDate: '2025-01-01T00:00:00.000Z',
+  completionDates: [],
+  ...overrides,
+})
+
+describe('nextSortOrderForNewHabit', () => {
+  it('returns 0 when there are no active habits', () => {
+    expect(nextSortOrderForNewHabit([])).toBe(0)
+    expect(nextSortOrderForNewHabit([h({ id: 'a', archivedAt: '2025-02-01T00:00:00.000Z' })])).toBe(0)
+  })
+
+  it('returns max active sortOrder plus one', () => {
+    expect(
+      nextSortOrderForNewHabit([
+        h({ id: 'a', sortOrder: 0 }),
+        h({ id: 'b', sortOrder: 5 }),
+        h({ id: 'c', archivedAt: '2025-02-01T00:00:00.000Z', sortOrder: 99 }),
+      ])
+    ).toBe(6)
+  })
+
+  it('ignores undefined sortOrder on active habits', () => {
+    expect(nextSortOrderForNewHabit([h({ id: 'a' }), h({ id: 'b' })])).toBe(0)
+  })
+})

--- a/src/utils/habit/nextSortOrderForNewHabit.ts
+++ b/src/utils/habit/nextSortOrderForNewHabit.ts
@@ -1,0 +1,13 @@
+import type { Habit } from '../../types/habit'
+
+/** Next sortOrder for a new active habit (append after current active habits). */
+export function nextSortOrderForNewHabit(habits: Habit[]): number {
+  let max = -1
+  for (const h of habits) {
+    if (h.archivedAt) continue
+    if (h.sortOrder !== undefined && h.sortOrder > max) {
+      max = h.sortOrder
+    }
+  }
+  return max + 1
+}

--- a/src/utils/habit/sortHabitsByDisplayOrder.test.ts
+++ b/src/utils/habit/sortHabitsByDisplayOrder.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { compareHabitsDisplayOrder, sortHabitsByDisplayOrder } from './sortHabitsByDisplayOrder'
+import type { Habit } from '../../types/habit'
+
+const base = (overrides: Partial<Habit>): Habit => ({
+  id: 'id',
+  createdDate: '2025-01-01T00:00:00.000Z',
+  completionDates: [],
+  ...overrides,
+})
+
+describe('compareHabitsDisplayOrder', () => {
+  it('orders by sortOrder ascending', () => {
+    expect(
+      compareHabitsDisplayOrder(
+        base({ id: 'b', sortOrder: 1 }),
+        base({ id: 'a', sortOrder: 0 })
+      )
+    ).toBeGreaterThan(0)
+  })
+
+  it('places missing sortOrder after explicit sortOrder', () => {
+    expect(compareHabitsDisplayOrder(base({ id: 'a', sortOrder: 0 }), base({ id: 'b' }))).toBeLessThan(0)
+  })
+
+  it('ties with createdDate then id', () => {
+    expect(
+      compareHabitsDisplayOrder(
+        base({ id: 'b', sortOrder: 0, createdDate: '2025-01-02T00:00:00.000Z' }),
+        base({ id: 'a', sortOrder: 0, createdDate: '2025-01-01T00:00:00.000Z' })
+      )
+    ).toBeGreaterThan(0)
+    expect(
+      compareHabitsDisplayOrder(
+        base({ id: 'a', sortOrder: 0, createdDate: '2025-01-01T00:00:00.000Z' }),
+        base({ id: 'b', sortOrder: 0, createdDate: '2025-01-01T00:00:00.000Z' })
+      )
+    ).toBeLessThan(0)
+  })
+})
+
+describe('sortHabitsByDisplayOrder', () => {
+  it('returns a new sorted array without mutating input', () => {
+    const input = [
+      base({ id: 'z', sortOrder: 2 }),
+      base({ id: 'x', sortOrder: 0 }),
+      base({ id: 'y', sortOrder: 1 }),
+    ]
+    const out = sortHabitsByDisplayOrder(input)
+    expect(out.map(h => h.id)).toEqual(['x', 'y', 'z'])
+    expect(input.map(h => h.id)).toEqual(['z', 'x', 'y'])
+  })
+})

--- a/src/utils/habit/sortHabitsByDisplayOrder.ts
+++ b/src/utils/habit/sortHabitsByDisplayOrder.ts
@@ -1,0 +1,15 @@
+import type { Habit } from '../../types/habit'
+
+/** Lower sortOrder first; missing sortOrder sorts after defined values. Tie-break: createdDate, id. */
+export function compareHabitsDisplayOrder(a: Habit, b: Habit): number {
+  const orderA = a.sortOrder ?? Number.MAX_SAFE_INTEGER
+  const orderB = b.sortOrder ?? Number.MAX_SAFE_INTEGER
+  if (orderA !== orderB) return orderA - orderB
+  const byDate = a.createdDate.localeCompare(b.createdDate)
+  if (byDate !== 0) return byDate
+  return a.id.localeCompare(b.id)
+}
+
+export function sortHabitsByDisplayOrder(habits: Habit[]): Habit[] {
+  return [...habits].sort(compareHabitsDisplayOrder)
+}

--- a/src/utils/validation/validateHabit.test.ts
+++ b/src/utils/validation/validateHabit.test.ts
@@ -364,6 +364,47 @@ describe('validateHabit', () => {
     })
   })
 
+  describe('sortOrder validation', () => {
+    it('should accept valid sortOrder', () => {
+      const habit: Habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        sortOrder: 0,
+      }
+      expect(() => validateHabit(habit)).not.toThrow()
+    })
+
+    it('should accept undefined sortOrder', () => {
+      const habit: Habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+      }
+      expect(() => validateHabit(habit)).not.toThrow()
+    })
+
+    it('should reject negative sortOrder', () => {
+      const habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        sortOrder: -1,
+      }
+      expect(() => validateHabit(habit)).toThrow('sortOrder')
+    })
+
+    it('should reject non-integer sortOrder', () => {
+      const habit = {
+        id: '1',
+        createdDate: '2025-01-01T00:00:00.000Z',
+        completionDates: [],
+        sortOrder: 1.5,
+      }
+      expect(() => validateHabit(habit)).toThrow('sortOrder')
+    })
+  })
+
   describe('archivedAt validation', () => {
     it('should accept habit with valid ISO 8601 archivedAt', () => {
       const habit: Habit = {

--- a/src/utils/validation/validateHabit.ts
+++ b/src/utils/validation/validateHabit.ts
@@ -130,6 +130,12 @@ export function validateHabit(habit: unknown): asserts habit is Habit {
     }
   }
 
+  if (habitObj.sortOrder !== undefined) {
+    if (typeof habitObj.sortOrder !== 'number' || !Number.isInteger(habitObj.sortOrder) || habitObj.sortOrder < 0) {
+      throw new Error('Habit sortOrder must be a non-negative integer if provided')
+    }
+  }
+
   if (habitObj.archivedAt !== undefined) {
     if (typeof habitObj.archivedAt !== 'string' || habitObj.archivedAt.trim() === '') {
       throw new Error('Habit archivedAt must be a non-empty string if provided')


### PR DESCRIPTION
## Description

- Reorder active habits by dragging and dropping; the new order is saved so it stays after you leave the app.
- On wider screens where habits show in a grid, dragging follows the grid layout instead of acting like a single column.
- Habit list can use the full width on medium and large screens for a cleaner grid.

Made with [Cursor](https://cursor.com)